### PR TITLE
remove new func from generated terra code

### DIFF
--- a/docs/terraform/aws_test.go
+++ b/docs/terraform/aws_test.go
@@ -42,12 +42,13 @@ func Example_awsVPC() {
 		Provider: &aws.Provider{
 			Region: terra.String("eu-north-1"),
 		},
-		VPC: aws_vpc.New(
-			"vpc", aws_vpc.Args{
+		VPC: &aws_vpc.Resource{
+			Name: "vpc",
+			Args: aws_vpc.Args{
 				CidrBlock:        terra.String("10.0.0.0/16"),
 				EnableDnsSupport: terra.Bool(true),
 			},
-		),
+		},
 	}
 	// Export the stack to Terraform HCL
 	var b bytes.Buffer
@@ -87,27 +88,29 @@ func Example_awsVPCWithSubnet() {
 		Subnet   *aws_subnet.Resource `validate:"required"`
 	}
 
-	vpc := aws_vpc.New(
-		"vpc", aws_vpc.Args{
+	vpc := aws_vpc.Resource{
+		Name: "vpc",
+		Args: aws_vpc.Args{
 			CidrBlock:        terra.String("10.0.0.0/16"),
 			EnableDnsSupport: terra.Bool(true),
 		},
-	)
-	subnet := aws_subnet.New(
-		"subnet", aws_subnet.Args{
+	}
+	subnet := aws_subnet.Resource{
+		Name: "subnet",
+		Args: aws_subnet.Args{
 			// Reference the VPC's ID, which will translate into a reference
 			// in the Terraform configuration
 			VpcId: vpc.Attributes().Id(),
 		},
-	)
+	}
 
 	// Initialise a stack with the AWS provider configuration
 	stack := AWSStack{
 		Provider: &aws.Provider{
 			Region: terra.String("eu-north-1"),
 		},
-		VPC:    vpc,
-		Subnet: subnet,
+		VPC:    &vpc,
+		Subnet: &subnet,
 	}
 	// Export the stack to Terraform HCL
 	var b bytes.Buffer
@@ -155,12 +158,13 @@ func Example_awsVPCImportState() {
 		Provider: &aws.Provider{
 			Region: terra.String("eu-north-1"),
 		},
-		VPC: aws_vpc.New(
-			"vpc", aws_vpc.Args{
+		VPC: &aws_vpc.Resource{
+			Name: "vpc",
+			Args: aws_vpc.Args{
 				CidrBlock:        terra.String("10.0.0.0/16"),
 				EnableDnsSupport: terra.Bool(true),
 			},
-		),
+		},
 	}
 
 	// At this point, you would invoke the Terraform CLI, and at a minimum

--- a/docs/terraform/localfile/localfile.go
+++ b/docs/terraform/localfile/localfile.go
@@ -22,12 +22,13 @@ func NewLocalFileStack(filename string) *LocalFileStack {
 			Path: "terraform.tfstate",
 		},
 		Provider: &local.Provider{},
-		File: local_file.New(
-			"file", local_file.Args{
+		File: &local_file.Resource{
+			Name: "file",
+			Args: local_file.Args{
 				Filename: terra.String(filename),
 				Content:  terra.String("contents"),
 			},
-		),
+		},
 	}
 }
 

--- a/docs/terraform/localfile/out/local/local_file/data_local_file.go
+++ b/docs/terraform/localfile/out/local/local_file/data_local_file.go
@@ -4,14 +4,6 @@ package local_file
 
 import "github.com/golingon/lingon/pkg/terra"
 
-// Data creates a new instance of [DataSource].
-func Data(name string, args DataArgs) *DataSource {
-	return &DataSource{
-		Args: args,
-		Name: name,
-	}
-}
-
 var _ terra.DataSource = (*DataSource)(nil)
 
 // DataSource represents the Terraform data resource local_file.

--- a/docs/terraform/localfile/out/local/local_file/local_file.go
+++ b/docs/terraform/localfile/out/local/local_file/local_file.go
@@ -10,14 +10,6 @@ import (
 	"github.com/golingon/lingon/pkg/terra"
 )
 
-// New creates a new instance of [Resource].
-func New(name string, args Args) *Resource {
-	return &Resource{
-		Args: args,
-		Name: name,
-	}
-}
-
 var _ terra.Resource = (*Resource)(nil)
 
 // Resource represents the Terraform resource local_file.

--- a/docs/terraform/localfile/out/local/local_sensitive_file/data_local_sensitive_file.go
+++ b/docs/terraform/localfile/out/local/local_sensitive_file/data_local_sensitive_file.go
@@ -4,14 +4,6 @@ package local_sensitive_file
 
 import "github.com/golingon/lingon/pkg/terra"
 
-// Data creates a new instance of [DataSource].
-func Data(name string, args DataArgs) *DataSource {
-	return &DataSource{
-		Args: args,
-		Name: name,
-	}
-}
-
 var _ terra.DataSource = (*DataSource)(nil)
 
 // DataSource represents the Terraform data resource local_sensitive_file.

--- a/docs/terraform/localfile/out/local/local_sensitive_file/local_sensitive_file.go
+++ b/docs/terraform/localfile/out/local/local_sensitive_file/local_sensitive_file.go
@@ -10,14 +10,6 @@ import (
 	"github.com/golingon/lingon/pkg/terra"
 )
 
-// New creates a new instance of [Resource].
-func New(name string, args Args) *Resource {
-	return &Resource{
-		Args: args,
-		Name: name,
-	}
-}
-
 var _ terra.Resource = (*Resource)(nil)
 
 // Resource represents the Terraform resource local_sensitive_file.

--- a/docs/terraform/readme.md
+++ b/docs/terraform/readme.md
@@ -196,12 +196,13 @@ stack := AWSStack{
 	Provider: &aws.Provider{
 		Region: terra.String("eu-north-1"),
 	},
-	VPC: aws_vpc.New(
-		"vpc", aws_vpc.Args{
+	VPC: &aws_vpc.Resource{
+		Name:	"vpc",
+		Args: aws_vpc.Args{
 			CidrBlock:		terra.String("10.0.0.0/16"),
 			EnableDnsSupport:	terra.Bool(true),
 		},
-	),
+	},
 }
 // Export the stack to Terraform HCL
 var b bytes.Buffer
@@ -249,27 +250,29 @@ type AWSStack struct {
 	Subnet		*aws_subnet.Resource	`validate:"required"`
 }
 
-vpc := aws_vpc.New(
-	"vpc", aws_vpc.Args{
+vpc := aws_vpc.Resource{
+	Name:	"vpc",
+	Args: aws_vpc.Args{
 		CidrBlock:		terra.String("10.0.0.0/16"),
 		EnableDnsSupport:	terra.Bool(true),
 	},
-)
-subnet := aws_subnet.New(
-	"subnet", aws_subnet.Args{
+}
+subnet := aws_subnet.Resource{
+	Name:	"subnet",
+	Args: aws_subnet.Args{
 		// Reference the VPC's ID, which will translate into a reference
 		// in the Terraform configuration
 		VpcId: vpc.Attributes().Id(),
 	},
-)
+}
 
 // Initialise a stack with the AWS provider configuration
 stack := AWSStack{
 	Provider: &aws.Provider{
 		Region: terra.String("eu-north-1"),
 	},
-	VPC:	vpc,
-	Subnet:	subnet,
+	VPC:	&vpc,
+	Subnet:	&subnet,
 }
 // Export the stack to Terraform HCL
 var b bytes.Buffer
@@ -328,12 +331,13 @@ stack := AWSStack{
 	Provider: &aws.Provider{
 		Region: terra.String("eu-north-1"),
 	},
-	VPC: aws_vpc.New(
-		"vpc", aws_vpc.Args{
+	VPC: &aws_vpc.Resource{
+		Name:	"vpc",
+		Args: aws_vpc.Args{
 			CidrBlock:		terra.String("10.0.0.0/16"),
 			EnableDnsSupport:	terra.Bool(true),
 		},
-	),
+	},
 }
 
 // At this point, you would invoke the Terraform CLI, and at a minimum
@@ -395,12 +399,13 @@ var (
 	B	= terra.Bool
 )
 
-_ = aws_vpc.New(
-	"vpc", aws_vpc.Args{
+_ = aws_vpc.Resource{
+	Name:	"vpc",
+	Args: aws_vpc.Args{
 		CidrBlock:		S("10.0.0.0/16"),
 		EnableDnsSupport:	B(true),
 	},
-)
+}
 ```
 
 We also highly recommend not passing `terra` values between stacks or Go modules.

--- a/docs/terraform/types_test.go
+++ b/docs/terraform/types_test.go
@@ -14,10 +14,11 @@ func Example_typesVars() {
 		B = terra.Bool
 	)
 
-	_ = aws_vpc.New(
-		"vpc", aws_vpc.Args{
+	_ = aws_vpc.Resource{
+		Name: "vpc",
+		Args: aws_vpc.Args{
 			CidrBlock:        S("10.0.0.0/16"),
 			EnableDnsSupport: B(true),
 		},
-	)
+	}
 }

--- a/pkg/internal/terrajen/data.go
+++ b/pkg/internal/terrajen/data.go
@@ -17,41 +17,12 @@ func DataSourceFile(s *Schema) *jen.File {
 	f.ImportAlias(pkgHCL, "hcl")
 	f.ImportName(pkgTerra, pkgTerraAlias)
 	f.HeaderComment(HeaderComment)
-	f.Add(dataNewFunc(s))
 	f.Add(dataStructCompileCheck(s))
 	f.Add(dataStruct(s))
 	f.Add(argsStruct(s))
 	f.Add(attributesStruct(s))
 
 	return f
-}
-
-func dataNewFunc(s *Schema) *jen.Statement {
-	return jen.Comment(
-		fmt.Sprintf(
-			"%s creates a new instance of [%s].",
-			s.NewFuncName,
-			s.StructName,
-		),
-	).
-		Line().
-		Func().Id(s.NewFuncName).Params(
-		jen.Id("name").String(),
-		jen.Id("args").Id(s.ArgumentStructName),
-	).
-		// Return
-		Op("*").Id(s.StructName).
-		// Block
-		Block(
-			jen.Return(
-				jen.Op("&").Id(s.StructName).Values(
-					jen.Dict{
-						jen.Id(idFieldName): jen.Id("name"),
-						jen.Id(idFieldArgs): jen.Id("args"),
-					},
-				),
-			),
-		)
 }
 
 func dataStructCompileCheck(s *Schema) *jen.Statement {

--- a/pkg/internal/terrajen/generator.go
+++ b/pkg/internal/terrajen/generator.go
@@ -71,8 +71,7 @@ func (a *ProviderGenerator) SchemaProvider(sb *tfjson.SchemaBlock) *Schema {
 		StateStructName:      "n/a",      // Providers do not have a state.
 		Receiver:             structReceiverFromName("provider"),
 
-		NewFuncName: "n/a", // Not used.
-		SubPkgName:  a.ProviderName,
+		SubPkgName: a.ProviderName,
 		SubPkgPath: filepath.Join(
 			a.GeneratedPackageLocation,
 			"provider_types"+fileExtension,
@@ -113,8 +112,7 @@ func (a *ProviderGenerator) SchemaResource(
 			name,
 		), // iam_role => ir
 
-		NewFuncName: "New",
-		SubPkgName:  name, // aws_iam_role => aws_iam_role
+		SubPkgName: name, // aws_iam_role => aws_iam_role
 		SubPkgPath: filepath.Join(
 			a.GeneratedPackageLocation,
 			name,
@@ -157,8 +155,7 @@ func (a *ProviderGenerator) SchemaData(
 			name,
 		), // iam_role => ir
 
-		NewFuncName: "Data",
-		SubPkgName:  name, // aws_iam_role => aws_iam_role
+		SubPkgName: name, // aws_iam_role => aws_iam_role
 		SubPkgPath: filepath.Join(
 			a.GeneratedPackageLocation,
 			name,
@@ -214,8 +211,7 @@ type Schema struct {
 
 	Receiver string // iam_role => ir
 
-	NewFuncName string // iam_role => NewIamRole
-	SubPkgName  string // iam_role => iamrole
+	SubPkgName string // iam_role => iamrole
 	// SubPkgPath is the filepath for the schema entities types (args,
 	// attributes, state).
 	SubPkgPath string

--- a/pkg/internal/terrajen/resource.go
+++ b/pkg/internal/terrajen/resource.go
@@ -17,7 +17,6 @@ func ResourceFile(s *Schema) *jen.File {
 	f.ImportAlias(pkgHCL, pkgHCLAlias)
 	f.ImportName(pkgTerra, pkgTerraAlias)
 	f.HeaderComment(HeaderComment)
-	f.Add(resourceNewFunc(s))
 	f.Add(resourceStructCompileCheck(s))
 	f.Add(resourceStruct(s))
 	f.Add(argsStruct(s))
@@ -25,36 +24,6 @@ func ResourceFile(s *Schema) *jen.File {
 	f.Add(resourceStateStruct(s))
 
 	return f
-}
-
-func resourceNewFunc(s *Schema) *jen.Statement {
-	return jen.Comment(
-		fmt.Sprintf(
-			"%s creates a new instance of [%s].",
-			s.NewFuncName,
-			s.StructName,
-		),
-	).
-		Line().
-		Func().
-		// Name
-		Id(s.NewFuncName).Params(
-		jen.Id("name").String(),
-		jen.Id("args").Id(s.ArgumentStructName),
-	).
-		// Return
-		Op("*").Id(s.StructName).
-		// Block
-		Block(
-			jen.Return(
-				jen.Op("&").Id(s.StructName).Values(
-					jen.Dict{
-						jen.Id(idFieldName): jen.Id("name"),
-						jen.Id(idFieldArgs): jen.Id("args"),
-					},
-				),
-			),
-		)
 }
 
 func resourceStructCompileCheck(s *Schema) *jen.Statement {

--- a/pkg/terragen/testdata/golden/aws_emr_cluster/provider.txtar
+++ b/pkg/terragen/testdata/golden/aws_emr_cluster/provider.txtar
@@ -2292,14 +2292,6 @@ import (
 	"io"
 )
 
-// New creates a new instance of [Resource].
-func New(name string, args Args) *Resource {
-	return &Resource{
-		Args: args,
-		Name: name,
-	}
-}
-
 var _ terra.Resource = (*Resource)(nil)
 
 // Resource represents the Terraform resource aws_emr_cluster.

--- a/pkg/terragen/testdata/golden/aws_iam_role/provider.txtar
+++ b/pkg/terragen/testdata/golden/aws_iam_role/provider.txtar
@@ -2292,14 +2292,6 @@ import (
 	"io"
 )
 
-// New creates a new instance of [Resource].
-func New(name string, args Args) *Resource {
-	return &Resource{
-		Args: args,
-		Name: name,
-	}
-}
-
 var _ terra.Resource = (*Resource)(nil)
 
 // Resource represents the Terraform resource aws_iam_role.
@@ -2550,14 +2542,6 @@ type InlinePolicyState struct {
 package aws_iam_role
 
 import "github.com/golingon/lingon/pkg/terra"
-
-// Data creates a new instance of [DataSource].
-func Data(name string, args DataArgs) *DataSource {
-	return &DataSource{
-		Args: args,
-		Name: name,
-	}
-}
 
 var _ terra.DataSource = (*DataSource)(nil)
 

--- a/pkg/terragen/testdata/golden/aws_securitylake_subscriber/provider.txtar
+++ b/pkg/terragen/testdata/golden/aws_securitylake_subscriber/provider.txtar
@@ -2292,14 +2292,6 @@ import (
 	"io"
 )
 
-// New creates a new instance of [Resource].
-func New(name string, args Args) *Resource {
-	return &Resource{
-		Args: args,
-		Name: name,
-	}
-}
-
 var _ terra.Resource = (*Resource)(nil)
 
 // Resource represents the Terraform resource aws_securitylake_subscriber.


### PR DESCRIPTION
Based on feedback using the generated code, creating structs explicitly
improves readability and makes adding meta arguments (like DependsOn)
easier.
