### PR TITLE
adjust main GHA to use cmd/tools/ci instead of its own versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,14 +31,6 @@ jobs:
           check-latest: true
           cache-dependency-path: ./go.mod
 
-      - name: go test
-        run: go test -v ./pkg/...
-
-      - name: git diff
-        run: git --no-pager diff HEAD --exit-code
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@9d1e0624a798bb64f6c3cea93db47765312263dc # v5.1.0
-        with:
-          args: -v --timeout 1m
+      - name: run CI
+        run: go run cmd/tools/ci/*.go -pr -doc -nodiff
 

--- a/cmd/kygo/cli.go
+++ b/cmd/kygo/cli.go
@@ -161,7 +161,7 @@ func run(
 	// directory
 	files, err := kubeutil.ListYAMLFiles(in)
 	if err != nil {
-		slog.Error("list yaml files", err)
+		slog.Error("list yaml files", "error", err)
 	}
 
 	fmt.Printf("files:\n- %s\n", strings.Join(files, "\n- "))

--- a/cmd/tools/ci/ci.go
+++ b/cmd/tools/ci/ci.go
@@ -36,7 +36,7 @@ const (
 
 	// goCILint is for linting code
 	goCILintRepo    = "github.com/golangci/golangci-lint/cmd/golangci-lint"
-	goCILintVersion = "@v1.57.2"
+	goCILintVersion = "@v1.58.0"
 	goCILint        = goCILintRepo + goCILintVersion
 
 	// goFumpt is mvdan.cc/gofumpt to format code

--- a/pkg/internal/terrajen/example_generator_test.go
+++ b/pkg/internal/terrajen/example_generator_test.go
@@ -72,7 +72,7 @@ func Example() {
 	// In this case we will write it to a buffer and print to stdout
 	var pb bytes.Buffer
 	if err := provFile.Render(&pb); err != nil {
-		slog.Error("rendering provider file", err)
+		slog.Error("rendering provider file", "error", err)
 		return
 	}
 	fmt.Println(pb.String())


### PR DESCRIPTION
The main GHA was reporting linter issues that were not flagged in the PR
because the version of golang-lint-ci was different.

Update the version of golang-lint-ci and make main GHA use our internal
ci Go program as well.
