### PR TITLE
kube import: make string handling simple

### DIFF
--- a/pkg/kube/ast.go
+++ b/pkg/kube/ast.go
@@ -49,7 +49,7 @@ func (j *jamel) convertValue(v reflect.Value, isFromPtr bool) *jen.Statement {
 	switch v.Type().Kind() {
 	case reflect.String:
 		return returnTypeAlias(
-			v, reflect.String.String(), rawString(v.String()),
+			v, reflect.String.String(), jen.Lit(v.String()),
 		)
 	case reflect.Bool:
 		return returnTypeAlias(
@@ -378,13 +378,13 @@ func convertConfigMapData(
 									jen.Comment(c).Line(),
 									jen.Lit(k.String()),
 									jen.Op(":"),
-									rawString(field.MapIndex(k).String()),
+									jen.Lit(field.MapIndex(k).String()),
 								)
 							} else {
 								g.Add(
 									jen.Lit(k.String()),
 									jen.Op(":"),
-									rawString(field.MapIndex(k).String()),
+									jen.Lit(field.MapIndex(k).String()),
 								)
 							}
 						},
@@ -393,35 +393,6 @@ func convertConfigMapData(
 			}
 		},
 	)
-}
-
-func rawString(s string) *jen.Statement {
-	if len(s) == 0 {
-		return jen.Lit("")
-	}
-	hasQuote := strings.Contains(s, `"`)
-	hasBacktick := strings.Contains(s, "`")
-	hasNewLine := strings.Contains(s, "\n")
-
-	if hasNewLine {
-		if hasBacktick {
-			return jen.Lit(s)
-		}
-		return jen.Custom(
-			jen.Options{Open: "`", Close: "`", Multi: true},
-			jen.Op(s),
-		)
-	}
-	if hasQuote && hasBacktick {
-		return jen.Lit(s)
-	}
-	if hasQuote {
-		return jen.Custom(
-			jen.Options{Open: "`", Close: "`", Multi: false},
-			jen.Op(s),
-		)
-	}
-	return jen.Lit(s)
 }
 
 // convertSecret converts a Secret to a jen statement.

--- a/pkg/kube/import_test.go
+++ b/pkg/kube/import_test.go
@@ -5,7 +5,6 @@ package kube_test
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"go/parser"
 	"go/token"
@@ -26,8 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 )
-
-var updateGolden = flag.Bool("update-golden", false, "update golden files")
 
 const defaultImportOutputDir = "out/import"
 
@@ -270,7 +267,7 @@ func TestImport(t *testing.T) {
 					"testdata", "golden",
 					strings.ReplaceAll(tc.Name, " ", "_")+".txt",
 				)
-				if *updateGolden {
+				if *kube.UpdateGolden {
 					err := os.WriteFile(
 						goldenFile,
 						txtar.Format(ar),
@@ -371,10 +368,18 @@ func TestImport_SaveFromReader(t *testing.T) {
 	sort.Strings(got)
 	tu.AssertEqualSlice(t, want, got)
 
+	goldenFile := filepath.Join("testdata", "golden", "import_save_from_reader.txt")
+	if *kube.UpdateGolden {
+		err := os.WriteFile(
+			goldenFile,
+			txtar.Format(ar),
+			os.ModePerm,
+		)
+		tu.AssertNoError(t, err, "writing golden file")
+		t.Skip("update golden files")
+	}
 	// compare content
-	golden, err := txtar.ParseFile(
-		filepath.Join("testdata", "golden", "import_save_from_reader.txt"),
-	)
+	golden, err := txtar.ParseFile(goldenFile)
 	tu.AssertNoError(t, err, "reading golden file")
 	if diff := tu.DiffTxtarSort(ar, golden); diff != "" {
 		t.Fatal(tu.Callers(), diff)
@@ -460,14 +465,23 @@ func TestImport_ReaderWriter(t *testing.T) {
 	sort.Strings(got)
 	tu.AssertEqualSlice(t, want, got)
 
-	// compare content
-	golden, err := txtar.ParseFile(
-		filepath.Join(
-			"testdata",
-			"golden",
-			"import_reader_writer.txt",
-		),
+	goldenFile := filepath.Join(
+		"testdata",
+		"golden",
+		"import_reader_writer.txt",
 	)
+	if *kube.UpdateGolden {
+		err := os.WriteFile(
+			goldenFile,
+			txtar.Format(ar),
+			os.ModePerm,
+		)
+		tu.AssertNoError(t, err, "writing golden file")
+		t.Skip("update golden files")
+	}
+
+	// compare content
+	golden, err := txtar.ParseFile(goldenFile)
 	tu.AssertNoError(t, err, "reading golden file")
 	if diff := tu.DiffTxtarSort(ar, golden); diff != "" {
 		t.Fatal(tu.Callers(), diff)

--- a/pkg/kube/testdata/golden/cm-rawstring.golden
+++ b/pkg/kube/testdata/golden/cm-rawstring.golden
@@ -1,53 +1,6 @@
 &v1.ConfigMap{
 	Data: map[string]string{
-		"nats.conf": `
-
-# NATS Clients Port
-port: 4222
-# PID file shared with configuration reloader.
-pid_file: "/var/run/nats/nats.pid"
-###############
-#             #
-# Monitoring  #
-#             #
-###############
-http: 8222
-server_name:$POD_NAME
-server_tags: [
-    "mem:4Gi",
-]
-###################################
-#                                 #
-# NATS JetStream                  #
-#                                 #
-###################################
-jetstream {
-  max_mem:2G
-  store_dir: "/data"
-  max_file:10Gi
-  unique_tag: "natsuniquetag"
-}
-###################################
-#                                 #
-# NATS Full Mesh Clustering Setup #
-#                                 #
-###################################
-cluster {
-  name: natscluster
-  port: 6222
-  routes = [
-    nats://nats-0.nats.nats.svc.cluster.local:6222
-    nats://nats-1.nats.nats.svc.cluster.local:6222
-    nats://nats-2.nats.nats.svc.cluster.local:6222
-
-  ]
-  cluster_advertise: $CLUSTER_ADVERTISE
-  connect_retries: 120
-}
-lame_duck_grace_period: 10s
-lame_duck_duration: 30s
-
-`},
+		"nats.conf": "\n# NATS Clients Port\nport: 4222\n# PID file shared with configuration reloader.\npid_file: \"/var/run/nats/nats.pid\"\n###############\n#             #\n# Monitoring  #\n#             #\n###############\nhttp: 8222\nserver_name:$POD_NAME\nserver_tags: [\n    \"mem:4Gi\",\n]\n###################################\n#                                 #\n# NATS JetStream                  #\n#                                 #\n###################################\njetstream {\n  max_mem:2G\n  store_dir: \"/data\"\n  max_file:10Gi\n  unique_tag: \"natsuniquetag\"\n}\n###################################\n#                                 #\n# NATS Full Mesh Clustering Setup #\n#                                 #\n###################################\ncluster {\n  name: natscluster\n  port: 6222\n  routes = [\n    nats://nats-0.nats.nats.svc.cluster.local:6222\n    nats://nats-1.nats.nats.svc.cluster.local:6222\n    nats://nats-2.nats.nats.svc.cluster.local:6222\n\n  ]\n  cluster_advertise: $CLUSTER_ADVERTISE\n  connect_retries: 120\n}\nlame_duck_grace_period: 10s\nlame_duck_duration: 30s\n"},
 	ObjectMeta: v11.ObjectMeta{Name: "webapp-config"},
 	TypeMeta: v11.TypeMeta{
 		APIVersion: "v1",

--- a/pkg/kube/testdata/golden/crd-subresources.golden
+++ b/pkg/kube/testdata/golden/crd-subresources.golden
@@ -21,7 +21,7 @@
 		Scope: v1.ResourceScope("Namespaced"),
 		Versions: []v1.CustomResourceDefinitionVersion{v1.CustomResourceDefinitionVersion{
 			AdditionalPrinterColumns: []v1.CustomResourceColumnDefinition{v1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].status",
 				Name:     "Ready",
 				Type:     "string",
 			}, v1.CustomResourceColumnDefinition{
@@ -34,7 +34,7 @@
 				Priority: int32(1),
 				Type:     "string",
 			}, v1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].message`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].message",
 				Name:     "Status",
 				Priority: int32(1),
 				Type:     "string",
@@ -84,11 +84,8 @@
 								Type:        "array",
 							},
 							"duration": v1.JSONSchemaProps{
-								Description: `
-Requested 'duration' (i.e. lifetime) of the Certificate. Note that the issuer may choose to ignore the requested duration, just like any other requested attribute. 
- If unset, this defaults to 90 days. Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
-`,
-								Type: "string",
+								Description: "Requested 'duration' (i.e. lifetime) of the Certificate. Note that the issuer may choose to ignore the requested duration, just like any other requested attribute. \n If unset, this defaults to 90 days. Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.",
+								Type:        "string",
 							},
 							"emailAddresses": v1.JSONSchemaProps{
 								Description: "Requested email subject alternative names.",
@@ -96,11 +93,8 @@ Requested 'duration' (i.e. lifetime) of the Certificate. Note that the issuer ma
 								Type:        "array",
 							},
 							"encodeUsagesInRequest": v1.JSONSchemaProps{
-								Description: `
-Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR. 
- This option defaults to true, and should only be disabled if the target issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
-`,
-								Type: "boolean",
+								Description: "Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR. \n This option defaults to true, and should only be disabled if the target issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.",
+								Type:        "boolean",
 							},
 							"ipAddresses": v1.JSONSchemaProps{
 								Description: "Requested IP address subject alternative names.",
@@ -264,7 +258,7 @@ Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR
 								Items: &v1.JSONSchemaPropsOrArray{Schema: &v1.JSONSchemaProps{
 									Properties: map[string]v1.JSONSchemaProps{
 										"oid": v1.JSONSchemaProps{
-											Description: `OID is the object identifier for the otherName SAN. The object identifier must be expressed as a dotted string, for example, "1.2.840.113556.1.4.221".`,
+											Description: "OID is the object identifier for the otherName SAN. The object identifier must be expressed as a dotted string, for example, \"1.2.840.113556.1.4.221\".",
 											Type:        "string",
 										},
 										"utf8Value": v1.JSONSchemaProps{
@@ -389,12 +383,9 @@ Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR
 							"usages": v1.JSONSchemaProps{
 								Description: "Requested key usages and extended key usages. These usages are used to set the `usages` field on the created CertificateRequest resources. If `encodeUsagesInRequest` is unset or set to `true`, the usages will additionally be encoded in the `request` field which contains the CSR blob. \n If unset, defaults to `digital signature` and `key encipherment`.",
 								Items: &v1.JSONSchemaPropsOrArray{Schema: &v1.JSONSchemaProps{
-									Description: `
-KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 
- Valid KeyUsage values are as follows: "signing", "digital signature", "content commitment", "key encipherment", "key agreement", "data encipherment", "cert sign", "crl sign", "encipher only", "decipher only", "any", "server auth", "client auth", "code signing", "email protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec user", "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
-`,
-									Enum: []v1.JSON{v1.JSON{Raw: []byte("\"signing\"")}, v1.JSON{Raw: []byte("\"digital signature\"")}, v1.JSON{Raw: []byte("\"content commitment\"")}, v1.JSON{Raw: []byte("\"key encipherment\"")}, v1.JSON{Raw: []byte("\"key agreement\"")}, v1.JSON{Raw: []byte("\"data encipherment\"")}, v1.JSON{Raw: []byte("\"cert sign\"")}, v1.JSON{Raw: []byte("\"crl sign\"")}, v1.JSON{Raw: []byte("\"encipher only\"")}, v1.JSON{Raw: []byte("\"decipher only\"")}, v1.JSON{Raw: []byte("\"any\"")}, v1.JSON{Raw: []byte("\"server auth\"")}, v1.JSON{Raw: []byte("\"client auth\"")}, v1.JSON{Raw: []byte("\"code signing\"")}, v1.JSON{Raw: []byte("\"email protection\"")}, v1.JSON{Raw: []byte("\"s/mime\"")}, v1.JSON{Raw: []byte("\"ipsec end system\"")}, v1.JSON{Raw: []byte("\"ipsec tunnel\"")}, v1.JSON{Raw: []byte("\"ipsec user\"")}, v1.JSON{Raw: []byte("\"timestamping\"")}, v1.JSON{Raw: []byte("\"ocsp signing\"")}, v1.JSON{Raw: []byte("\"microsoft sgc\"")}, v1.JSON{Raw: []byte("\"netscape sgc\"")}},
-									Type: "string",
+									Description: "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 \n Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\"",
+									Enum:        []v1.JSON{v1.JSON{Raw: []byte("\"signing\"")}, v1.JSON{Raw: []byte("\"digital signature\"")}, v1.JSON{Raw: []byte("\"content commitment\"")}, v1.JSON{Raw: []byte("\"key encipherment\"")}, v1.JSON{Raw: []byte("\"key agreement\"")}, v1.JSON{Raw: []byte("\"data encipherment\"")}, v1.JSON{Raw: []byte("\"cert sign\"")}, v1.JSON{Raw: []byte("\"crl sign\"")}, v1.JSON{Raw: []byte("\"encipher only\"")}, v1.JSON{Raw: []byte("\"decipher only\"")}, v1.JSON{Raw: []byte("\"any\"")}, v1.JSON{Raw: []byte("\"server auth\"")}, v1.JSON{Raw: []byte("\"client auth\"")}, v1.JSON{Raw: []byte("\"code signing\"")}, v1.JSON{Raw: []byte("\"email protection\"")}, v1.JSON{Raw: []byte("\"s/mime\"")}, v1.JSON{Raw: []byte("\"ipsec end system\"")}, v1.JSON{Raw: []byte("\"ipsec tunnel\"")}, v1.JSON{Raw: []byte("\"ipsec user\"")}, v1.JSON{Raw: []byte("\"timestamping\"")}, v1.JSON{Raw: []byte("\"ocsp signing\"")}, v1.JSON{Raw: []byte("\"microsoft sgc\"")}, v1.JSON{Raw: []byte("\"netscape sgc\"")}},
+									Type:        "string",
 								}},
 								Type: "array",
 							},

--- a/pkg/kube/testdata/golden/import_list_object.txt
+++ b/pkg/kube/testdata/golden/import_list_object.txt
@@ -180,21 +180,18 @@ var BackupsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 								Type:        "boolean",
 							},
 							"defaultVolumesToRestic": apiextensionsv1.JSONSchemaProps{
-								Description: `
-DefaultVolumesToRestic specifies whether restic should be used to take a backup of all pod volumes by default. 
- Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
-`,
-								Nullable: true,
-								Type:     "boolean",
+								Description: "DefaultVolumesToRestic specifies whether restic should be used to take a backup of all pod volumes by default. \n Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.",
+								Nullable:    true,
+								Type:        "boolean",
 							},
 							"excludedClusterScopedResources": apiextensionsv1.JSONSchemaProps{
-								Description: `ExcludedClusterScopedResources is a slice of cluster-scoped resource type names to exclude from the backup. If set to "*", all cluster-scoped resource types are excluded. The default value is empty.`,
+								Description: "ExcludedClusterScopedResources is a slice of cluster-scoped resource type names to exclude from the backup. If set to \"*\", all cluster-scoped resource types are excluded. The default value is empty.",
 								Items:       &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"}},
 								Nullable:    true,
 								Type:        "array",
 							},
 							"excludedNamespaceScopedResources": apiextensionsv1.JSONSchemaProps{
-								Description: `ExcludedNamespaceScopedResources is a slice of namespace-scoped resource type names to exclude from the backup. If set to "*", all namespace-scoped resource types are excluded. The default value is empty.`,
+								Description: "ExcludedNamespaceScopedResources is a slice of namespace-scoped resource type names to exclude from the backup. If set to \"*\", all namespace-scoped resource types are excluded. The default value is empty.",
 								Items:       &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"}},
 								Nullable:    true,
 								Type:        "array",
@@ -275,7 +272,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 															Allows: true,
 															Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 														},
-														Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+														Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 														Type:        "object",
 													},
 												},
@@ -286,7 +283,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 												Type:        "string",
 											},
 											"post": apiextensionsv1.JSONSchemaProps{
-												Description: `PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup. These are executed after all "additional items" from item actions are processed.`,
+												Description: "PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup. These are executed after all \"additional items\" from item actions are processed.",
 												Items: &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{
 													Description: "BackupResourceHook defines a hook for a resource.",
 													Properties: map[string]apiextensionsv1.JSONSchemaProps{"exec": apiextensionsv1.JSONSchemaProps{
@@ -321,7 +318,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 												Type: "array",
 											},
 											"pre": apiextensionsv1.JSONSchemaProps{
-												Description: `PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup. These are executed before any "additional items" from item actions are processed.`,
+												Description: "PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup. These are executed before any \"additional items\" from item actions are processed.",
 												Items: &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{
 													Description: "BackupResourceHook defines a hook for a resource.",
 													Properties: map[string]apiextensionsv1.JSONSchemaProps{"exec": apiextensionsv1.JSONSchemaProps{
@@ -370,13 +367,13 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 								Type:        "boolean",
 							},
 							"includedClusterScopedResources": apiextensionsv1.JSONSchemaProps{
-								Description: `IncludedClusterScopedResources is a slice of cluster-scoped resource type names to include in the backup. If set to "*", all cluster-scoped resource types are included. The default value is empty, which means only related cluster-scoped resources are included.`,
+								Description: "IncludedClusterScopedResources is a slice of cluster-scoped resource type names to include in the backup. If set to \"*\", all cluster-scoped resource types are included. The default value is empty, which means only related cluster-scoped resources are included.",
 								Items:       &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"}},
 								Nullable:    true,
 								Type:        "array",
 							},
 							"includedNamespaceScopedResources": apiextensionsv1.JSONSchemaProps{
-								Description: `IncludedNamespaceScopedResources is a slice of namespace-scoped resource type names to include in the backup. The default value is "*".`,
+								Description: "IncludedNamespaceScopedResources is a slice of namespace-scoped resource type names to include in the backup. The default value is \"*\".",
 								Items:       &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"}},
 								Nullable:    true,
 								Type:        "array",
@@ -430,7 +427,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 											Allows: true,
 											Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 										},
-										Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+										Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 										Type:        "object",
 									},
 								},
@@ -480,7 +477,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 												Allows: true,
 												Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 											},
-											Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+											Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 											Type:        "object",
 										},
 									},
@@ -494,7 +491,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 									Allows: true,
 									Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 								},
-								Description: `OrderedResources specifies the backup order of resources of specific Kind. The map key is the resource name and value is a list of object names separated by commas. Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".`,
+								Description: "OrderedResources specifies the backup order of resources of specific Kind. The map key is the resource name and value is a list of object names separated by commas. Each resource name has format \"namespace/objectname\".  For cluster resources, simply use \"objectname\".",
 								Nullable:    true,
 								Type:        "object",
 							},
@@ -780,12 +777,9 @@ var BackupstoragelocationsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 						Description: "BackupStorageLocationStatus defines the observed state of BackupStorageLocation",
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							"accessMode": apiextensionsv1.JSONSchemaProps{
-								Description: `
-AccessMode is an unused field. 
- Deprecated: there is now an AccessMode field on the Spec and this field will be removed entirely as of v2.0.
-`,
-								Enum: []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"ReadOnly\"")}, apiextensionsv1.JSON{Raw: []byte("\"ReadWrite\"")}},
-								Type: "string",
+								Description: "AccessMode is an unused field. \n Deprecated: there is now an AccessMode field on the Spec and this field will be removed entirely as of v2.0.",
+								Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"ReadOnly\"")}, apiextensionsv1.JSON{Raw: []byte("\"ReadWrite\"")}},
+								Type:        "string",
 							},
 							"lastSyncedRevision": apiextensionsv1.JSONSchemaProps{
 								Description: "LastSyncedRevision is the value of the `metadata/revision` file in the backup storage location the last time the BSL's contents were synced into the cluster. \n Deprecated: this field is no longer updated or used for detecting changes to the location's contents and will be removed entirely in v2.0.",
@@ -1082,7 +1076,7 @@ var PodvolumebackupsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 										Type:        "string",
 									},
 									"fieldPath": apiextensionsv1.JSONSchemaProps{
-										Description: `If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.`,
+										Description: "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
 										Type:        "string",
 									},
 									"kind": apiextensionsv1.JSONSchemaProps{
@@ -1281,7 +1275,7 @@ var PodvolumerestoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 										Type:        "string",
 									},
 									"fieldPath": apiextensionsv1.JSONSchemaProps{
-										Description: `If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.`,
+										Description: "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
 										Type:        "string",
 									},
 									"kind": apiextensionsv1.JSONSchemaProps{
@@ -1503,7 +1497,7 @@ var RestoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 															Allows: true,
 															Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 														},
-														Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+														Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 														Type:        "object",
 													},
 												},
@@ -1631,7 +1625,7 @@ var RestoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 											Allows: true,
 											Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 										},
-										Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+										Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 										Type:        "object",
 									},
 								},
@@ -1679,7 +1673,7 @@ var RestoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Allows: true,
 												Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 											},
-											Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+											Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 											Type:        "object",
 										},
 									},
@@ -1883,21 +1877,18 @@ var SchedulesIoCRD = &apiextensionsv1.CustomResourceDefinition{
 										Type:        "boolean",
 									},
 									"defaultVolumesToRestic": apiextensionsv1.JSONSchemaProps{
-										Description: `
-DefaultVolumesToRestic specifies whether restic should be used to take a backup of all pod volumes by default. 
- Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
-`,
-										Nullable: true,
-										Type:     "boolean",
+										Description: "DefaultVolumesToRestic specifies whether restic should be used to take a backup of all pod volumes by default. \n Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.",
+										Nullable:    true,
+										Type:        "boolean",
 									},
 									"excludedClusterScopedResources": apiextensionsv1.JSONSchemaProps{
-										Description: `ExcludedClusterScopedResources is a slice of cluster-scoped resource type names to exclude from the backup. If set to "*", all cluster-scoped resource types are excluded. The default value is empty.`,
+										Description: "ExcludedClusterScopedResources is a slice of cluster-scoped resource type names to exclude from the backup. If set to \"*\", all cluster-scoped resource types are excluded. The default value is empty.",
 										Items:       &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"}},
 										Nullable:    true,
 										Type:        "array",
 									},
 									"excludedNamespaceScopedResources": apiextensionsv1.JSONSchemaProps{
-										Description: `ExcludedNamespaceScopedResources is a slice of namespace-scoped resource type names to exclude from the backup. If set to "*", all namespace-scoped resource types are excluded. The default value is empty.`,
+										Description: "ExcludedNamespaceScopedResources is a slice of namespace-scoped resource type names to exclude from the backup. If set to \"*\", all namespace-scoped resource types are excluded. The default value is empty.",
 										Items:       &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"}},
 										Nullable:    true,
 										Type:        "array",
@@ -1978,7 +1969,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 																	Allows: true,
 																	Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 																},
-																Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+																Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 																Type:        "object",
 															},
 														},
@@ -1989,7 +1980,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 														Type:        "string",
 													},
 													"post": apiextensionsv1.JSONSchemaProps{
-														Description: `PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup. These are executed after all "additional items" from item actions are processed.`,
+														Description: "PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup. These are executed after all \"additional items\" from item actions are processed.",
 														Items: &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{
 															Description: "BackupResourceHook defines a hook for a resource.",
 															Properties: map[string]apiextensionsv1.JSONSchemaProps{"exec": apiextensionsv1.JSONSchemaProps{
@@ -2024,7 +2015,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 														Type: "array",
 													},
 													"pre": apiextensionsv1.JSONSchemaProps{
-														Description: `PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup. These are executed before any "additional items" from item actions are processed.`,
+														Description: "PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup. These are executed before any \"additional items\" from item actions are processed.",
 														Items: &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{
 															Description: "BackupResourceHook defines a hook for a resource.",
 															Properties: map[string]apiextensionsv1.JSONSchemaProps{"exec": apiextensionsv1.JSONSchemaProps{
@@ -2073,13 +2064,13 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 										Type:        "boolean",
 									},
 									"includedClusterScopedResources": apiextensionsv1.JSONSchemaProps{
-										Description: `IncludedClusterScopedResources is a slice of cluster-scoped resource type names to include in the backup. If set to "*", all cluster-scoped resource types are included. The default value is empty, which means only related cluster-scoped resources are included.`,
+										Description: "IncludedClusterScopedResources is a slice of cluster-scoped resource type names to include in the backup. If set to \"*\", all cluster-scoped resource types are included. The default value is empty, which means only related cluster-scoped resources are included.",
 										Items:       &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"}},
 										Nullable:    true,
 										Type:        "array",
 									},
 									"includedNamespaceScopedResources": apiextensionsv1.JSONSchemaProps{
-										Description: `IncludedNamespaceScopedResources is a slice of namespace-scoped resource type names to include in the backup. The default value is "*".`,
+										Description: "IncludedNamespaceScopedResources is a slice of namespace-scoped resource type names to include in the backup. The default value is \"*\".",
 										Items:       &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"}},
 										Nullable:    true,
 										Type:        "array",
@@ -2133,7 +2124,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 													Allows: true,
 													Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 												},
-												Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+												Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 												Type:        "object",
 											},
 										},
@@ -2183,7 +2174,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 														Allows: true,
 														Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 													},
-													Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+													Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 													Type:        "object",
 												},
 											},
@@ -2197,7 +2188,7 @@ DefaultVolumesToRestic specifies whether restic should be used to take a backup 
 											Allows: true,
 											Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 										},
-										Description: `OrderedResources specifies the backup order of resources of specific Kind. The map key is the resource name and value is a list of object names separated by commas. Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".`,
+										Description: "OrderedResources specifies the backup order of resources of specific Kind. The map key is the resource name and value is a list of object names separated by commas. Each resource name has format \"namespace/objectname\".  For cluster resources, simply use \"objectname\".",
 										Nullable:    true,
 										Type:        "object",
 									},

--- a/pkg/kube/testdata/golden/import_reader_writer.txt
+++ b/pkg/kube/testdata/golden/import_reader_writer.txt
@@ -10,65 +10,10 @@ import (
 
 var GrafanaCM = &corev1.ConfigMap{
 	Data: map[string]string{
-		"dashboardproviders.yaml": `
-apiVersion: 1
-providers:
-- disableDeletion: false
-  editable: true
-  folder: ""
-  name: default
-  options:
-    path: /var/lib/grafana/dashboards/default
-  orgId: 1
-  type: file
-
-`,
-		"datasources.yaml": `
-apiVersion: 1
-datasources:
-- access: proxy
-  name: Prometheus
-  type: prometheus
-  url: http://prometheus-server:80
-  version: 1
-
-`,
-		"download_dashboards.sh": `
-#!/usr/bin/env sh
-set -euf
-mkdir -p /var/lib/grafana/dashboards/default
-curl -skf \
---connect-timeout 60 \
---max-time 60 \
--H "Accept: application/json" \
--H "Content-Type: application/json;charset=UTF-8" \
-  "https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json" \
-> "/var/lib/grafana/dashboards/default/capacity-dashboard.json"
-curl -skf \
---connect-timeout 60 \
---max-time 60 \
--H "Accept: application/json" \
--H "Content-Type: application/json;charset=UTF-8" \
-  "https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-performance-dashboard.json" \
-> "/var/lib/grafana/dashboards/default/performance-dashboard.json"
-
-`,
-		"grafana.ini": `
-[analytics]
-check_for_updates = true
-[grafana_net]
-url = https://grafana.net
-[log]
-mode = console
-[paths]
-data = /var/lib/grafana/
-logs = /var/log/grafana
-plugins = /var/lib/grafana/plugins
-provisioning = /etc/grafana/provisioning
-[server]
-domain = ''
-
-`},
+		"dashboardproviders.yaml": "apiVersion: 1\nproviders:\n- disableDeletion: false\n  editable: true\n  folder: \"\"\n  name: default\n  options:\n    path: /var/lib/grafana/dashboards/default\n  orgId: 1\n  type: file\n",
+		"datasources.yaml":        "apiVersion: 1\ndatasources:\n- access: proxy\n  name: Prometheus\n  type: prometheus\n  url: http://prometheus-server:80\n  version: 1\n",
+		"download_dashboards.sh":  "#!/usr/bin/env sh\nset -euf\nmkdir -p /var/lib/grafana/dashboards/default\ncurl -skf \\\n--connect-timeout 60 \\\n--max-time 60 \\\n-H \"Accept: application/json\" \\\n-H \"Content-Type: application/json;charset=UTF-8\" \\\n  \"https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json\" \\\n> \"/var/lib/grafana/dashboards/default/capacity-dashboard.json\"\ncurl -skf \\\n--connect-timeout 60 \\\n--max-time 60 \\\n-H \"Accept: application/json\" \\\n-H \"Content-Type: application/json;charset=UTF-8\" \\\n  \"https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-performance-dashboard.json\" \\\n> \"/var/lib/grafana/dashboards/default/performance-dashboard.json\"\n",
+		"grafana.ini":             "[analytics]\ncheck_for_updates = true\n[grafana_net]\nurl = https://grafana.net\n[log]\nmode = console\n[paths]\ndata = /var/lib/grafana/\nlogs = /var/log/grafana\nplugins = /var/lib/grafana/plugins\nprovisioning = /etc/grafana/provisioning\n[server]\ndomain = ''\n"},
 	ObjectMeta: metav1.ObjectMeta{
 		Labels: map[string]string{
 			"app.kubernetes.io/instance":   "grafana",
@@ -518,13 +463,7 @@ import (
 
 var GrafanaTestCM = &corev1.ConfigMap{
 	Data: map[string]string{
-		"run.sh": `
-@test "Test Health" {
-  url="http://grafana/api/health"
-  code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
-  [ "$code" == "200" ]
-}
-`},
+		"run.sh": "@test \"Test Health\" {\n  url=\"http://grafana/api/health\"\n  code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')\n  [ \"$code\" == \"200\" ]\n}"},
 	ObjectMeta: metav1.ObjectMeta{
 		Annotations: map[string]string{
 			"helm.sh/hook":               "test-success",

--- a/pkg/kube/testdata/golden/import_save_from_reader.txt
+++ b/pkg/kube/testdata/golden/import_save_from_reader.txt
@@ -10,65 +10,10 @@ import (
 
 var GrafanaCM = &corev1.ConfigMap{
 	Data: map[string]string{
-		"dashboardproviders.yaml": `
-apiVersion: 1
-providers:
-- disableDeletion: false
-  editable: true
-  folder: ""
-  name: default
-  options:
-    path: /var/lib/grafana/dashboards/default
-  orgId: 1
-  type: file
-
-`,
-		"datasources.yaml": `
-apiVersion: 1
-datasources:
-- access: proxy
-  name: Prometheus
-  type: prometheus
-  url: http://prometheus-server:80
-  version: 1
-
-`,
-		"download_dashboards.sh": `
-#!/usr/bin/env sh
-set -euf
-mkdir -p /var/lib/grafana/dashboards/default
-curl -skf \
---connect-timeout 60 \
---max-time 60 \
--H "Accept: application/json" \
--H "Content-Type: application/json;charset=UTF-8" \
-  "https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json" \
-> "/var/lib/grafana/dashboards/default/capacity-dashboard.json"
-curl -skf \
---connect-timeout 60 \
---max-time 60 \
--H "Accept: application/json" \
--H "Content-Type: application/json;charset=UTF-8" \
-  "https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-performance-dashboard.json" \
-> "/var/lib/grafana/dashboards/default/performance-dashboard.json"
-
-`,
-		"grafana.ini": `
-[analytics]
-check_for_updates = true
-[grafana_net]
-url = https://grafana.net
-[log]
-mode = console
-[paths]
-data = /var/lib/grafana/
-logs = /var/log/grafana
-plugins = /var/lib/grafana/plugins
-provisioning = /etc/grafana/provisioning
-[server]
-domain = ''
-
-`},
+		"dashboardproviders.yaml": "apiVersion: 1\nproviders:\n- disableDeletion: false\n  editable: true\n  folder: \"\"\n  name: default\n  options:\n    path: /var/lib/grafana/dashboards/default\n  orgId: 1\n  type: file\n",
+		"datasources.yaml":        "apiVersion: 1\ndatasources:\n- access: proxy\n  name: Prometheus\n  type: prometheus\n  url: http://prometheus-server:80\n  version: 1\n",
+		"download_dashboards.sh":  "#!/usr/bin/env sh\nset -euf\nmkdir -p /var/lib/grafana/dashboards/default\ncurl -skf \\\n--connect-timeout 60 \\\n--max-time 60 \\\n-H \"Accept: application/json\" \\\n-H \"Content-Type: application/json;charset=UTF-8\" \\\n  \"https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json\" \\\n> \"/var/lib/grafana/dashboards/default/capacity-dashboard.json\"\ncurl -skf \\\n--connect-timeout 60 \\\n--max-time 60 \\\n-H \"Accept: application/json\" \\\n-H \"Content-Type: application/json;charset=UTF-8\" \\\n  \"https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-performance-dashboard.json\" \\\n> \"/var/lib/grafana/dashboards/default/performance-dashboard.json\"\n",
+		"grafana.ini":             "[analytics]\ncheck_for_updates = true\n[grafana_net]\nurl = https://grafana.net\n[log]\nmode = console\n[paths]\ndata = /var/lib/grafana/\nlogs = /var/log/grafana\nplugins = /var/lib/grafana/plugins\nprovisioning = /etc/grafana/provisioning\n[server]\ndomain = ''\n"},
 	ObjectMeta: metav1.ObjectMeta{
 		Labels: map[string]string{
 			"app.kubernetes.io/instance":   "grafana",
@@ -518,13 +463,7 @@ import (
 
 var GrafanaTestCM = &corev1.ConfigMap{
 	Data: map[string]string{
-		"run.sh": `
-@test "Test Health" {
-  url="http://grafana/api/health"
-  code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
-  [ "$code" == "200" ]
-}
-`},
+		"run.sh": "@test \"Test Health\" {\n  url=\"http://grafana/api/health\"\n  code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')\n  [ \"$code\" == \"200\" ]\n}"},
 	ObjectMeta: metav1.ObjectMeta{
 		Annotations: map[string]string{
 			"helm.sh/hook":               "test-success",

--- a/pkg/kube/testdata/golden/import_with_CRDs_and_remove_app_name_and_group_by_kind.txt
+++ b/pkg/kube/testdata/golden/import_with_CRDs_and_remove_app_name_and_group_by_kind.txt
@@ -202,17 +202,7 @@ var RbacCM = &corev1.ConfigMap{
 
 var SshKnownHostsCM = &corev1.ConfigMap{
 	Data: map[string]string{
-		"ssh_known_hosts": `
-bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
-github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
-gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=
-gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
-gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
-ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
-vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
-github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
-github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
-`},
+		"ssh_known_hosts": "bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==\ngithub.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==\ngitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=\ngitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf\ngitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9\nssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H\nvs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H\ngithub.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=\ngithub.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"},
 	ObjectMeta: metav1.ObjectMeta{
 		Labels: map[string]string{
 			"app.kubernetes.io/name":    "argocd-ssh-known-hosts-cm",
@@ -332,7 +322,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 										Description: "Backoff controls how to backoff on subsequent retries of failed syncs",
 										Properties: map[string]apiextensionsv1.JSONSchemaProps{
 											"duration": apiextensionsv1.JSONSchemaProps{
-												Description: `Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")`,
+												Description: "Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. \"2m\", \"1h\")",
 												Type:        "string",
 											},
 											"factor": apiextensionsv1.JSONSchemaProps{
@@ -528,7 +518,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Type:        "string",
 													},
 													"version": apiextensionsv1.JSONSchemaProps{
-														Description: `Version is the Helm version to use for templating ("3")`,
+														Description: "Version is the Helm version to use for templating (\"3\")",
 														Type:        "string",
 													},
 												},
@@ -794,7 +784,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 															Type:        "string",
 														},
 														"version": apiextensionsv1.JSONSchemaProps{
-															Description: `Version is the Helm version to use for templating ("3")`,
+															Description: "Version is the Helm version to use for templating (\"3\")",
 															Type:        "string",
 														},
 													},
@@ -1163,7 +1153,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Type:        "string",
 											},
 											"version": apiextensionsv1.JSONSchemaProps{
-												Description: `Version is the Helm version to use for templating ("3")`,
+												Description: "Version is the Helm version to use for templating (\"3\")",
 												Type:        "string",
 											},
 										},
@@ -1429,7 +1419,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 													Type:        "string",
 												},
 												"version": apiextensionsv1.JSONSchemaProps{
-													Description: `Version is the Helm version to use for templating ("3")`,
+													Description: "Version is the Helm version to use for templating (\"3\")",
 													Type:        "string",
 												},
 											},
@@ -1610,7 +1600,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Description: "Backoff controls how to backoff on subsequent retries of failed syncs",
 												Properties: map[string]apiextensionsv1.JSONSchemaProps{
 													"duration": apiextensionsv1.JSONSchemaProps{
-														Description: `Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")`,
+														Description: "Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. \"2m\", \"1h\")",
 														Type:        "string",
 													},
 													"factor": apiextensionsv1.JSONSchemaProps{
@@ -1848,7 +1838,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 															Type:        "string",
 														},
 														"version": apiextensionsv1.JSONSchemaProps{
-															Description: `Version is the Helm version to use for templating ("3")`,
+															Description: "Version is the Helm version to use for templating (\"3\")",
 															Type:        "string",
 														},
 													},
@@ -2114,7 +2104,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																Type:        "string",
 															},
 															"version": apiextensionsv1.JSONSchemaProps{
-																Description: `Version is the Helm version to use for templating ("3")`,
+																Description: "Version is the Helm version to use for templating (\"3\")",
 																Type:        "string",
 															},
 														},
@@ -2306,7 +2296,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Description: "Backoff controls how to backoff on subsequent retries of failed syncs",
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"duration": apiextensionsv1.JSONSchemaProps{
-																Description: `Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")`,
+																Description: "Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. \"2m\", \"1h\")",
 																Type:        "string",
 															},
 															"factor": apiextensionsv1.JSONSchemaProps{
@@ -2502,7 +2492,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																		Type:        "string",
 																	},
 																	"version": apiextensionsv1.JSONSchemaProps{
-																		Description: `Version is the Helm version to use for templating ("3")`,
+																		Description: "Version is the Helm version to use for templating (\"3\")",
 																		Type:        "string",
 																	},
 																},
@@ -2768,7 +2758,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																			Type:        "string",
 																		},
 																		"version": apiextensionsv1.JSONSchemaProps{
-																			Description: `Version is the Helm version to use for templating ("3")`,
+																			Description: "Version is the Helm version to use for templating (\"3\")",
 																			Type:        "string",
 																		},
 																	},
@@ -3144,7 +3134,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																Type:        "string",
 															},
 															"version": apiextensionsv1.JSONSchemaProps{
-																Description: `Version is the Helm version to use for templating ("3")`,
+																Description: "Version is the Helm version to use for templating (\"3\")",
 																Type:        "string",
 															},
 														},
@@ -3410,7 +3400,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																	Type:        "string",
 																},
 																"version": apiextensionsv1.JSONSchemaProps{
-																	Description: `Version is the Helm version to use for templating ("3")`,
+																	Description: "Version is the Helm version to use for templating (\"3\")",
 																	Type:        "string",
 																},
 															},
@@ -3784,7 +3774,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																Type:        "string",
 															},
 															"version": apiextensionsv1.JSONSchemaProps{
-																Description: `Version is the Helm version to use for templating ("3")`,
+																Description: "Version is the Helm version to use for templating (\"3\")",
 																Type:        "string",
 															},
 														},
@@ -4050,7 +4040,7 @@ var ApplicationsArgoprojIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																	Type:        "string",
 																},
 																"version": apiextensionsv1.JSONSchemaProps{
-																	Description: `Version is the Helm version to use for templating ("3")`,
+																	Description: "Version is the Helm version to use for templating (\"3\")",
 																	Type:        "string",
 																},
 															},

--- a/pkg/kube/testdata/golden/import_with_CRDs_and_remove_app_name_and_split_by_name.txt
+++ b/pkg/kube/testdata/golden/import_with_CRDs_and_remove_app_name_and_split_by_name.txt
@@ -157,32 +157,7 @@ var ConfigLoggingCM = &corev1.ConfigMap{
 	Data: map[string]string{
 		"loglevel.webhook": "error",
 		// https://github.com/uber-go/zap/blob/aa3e73ec0896f8b066ddf668597a02f89628ee50/config.go
-		"zap-logger-config": `
-{
-  "level": "debug",
-  "development": false,
-  "disableStacktrace": true,
-  "disableCaller": true,
-  "sampling": {
-    "initial": 100,
-    "thereafter": 100
-  },
-  "outputPaths": ["stdout"],
-  "errorOutputPaths": ["stderr"],
-  "encoding": "console",
-  "encoderConfig": {
-    "timeKey": "time",
-    "levelKey": "level",
-    "nameKey": "logger",
-    "callerKey": "caller",
-    "messageKey": "message",
-    "stacktraceKey": "stacktrace",
-    "levelEncoder": "capital",
-    "timeEncoder": "iso8601"
-  }
-}
-
-`},
+		"zap-logger-config": "{\n  \"level\": \"debug\",\n  \"development\": false,\n  \"disableStacktrace\": true,\n  \"disableCaller\": true,\n  \"sampling\": {\n    \"initial\": 100,\n    \"thereafter\": 100\n  },\n  \"outputPaths\": [\"stdout\"],\n  \"errorOutputPaths\": [\"stderr\"],\n  \"encoding\": \"console\",\n  \"encoderConfig\": {\n    \"timeKey\": \"time\",\n    \"levelKey\": \"level\",\n    \"nameKey\": \"logger\",\n    \"callerKey\": \"caller\",\n    \"messageKey\": \"message\",\n    \"stacktraceKey\": \"stacktrace\",\n    \"levelEncoder\": \"capital\",\n    \"timeEncoder\": \"iso8601\"\n  }\n}\n"},
 	ObjectMeta: metav1.ObjectMeta{
 		Labels: map[string]string{
 			"app.kubernetes.io/instance":   "karpenter",

--- a/pkg/kube/testdata/golden/import_with_CRDs_and_remove_app_name_containing_dash_and_group_by_kind.txt
+++ b/pkg/kube/testdata/golden/import_with_CRDs_and_remove_app_name_containing_dash_and_group_by_kind.txt
@@ -251,10 +251,7 @@ var AcraccesstokensGeneratorsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{apiextensionsv1.CustomResourceDefinitionVersion{
 			Name: "v1alpha1",
 			Schema: &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-				Description: `
-ACRAccessToken returns a Azure Container Registry token that can be used for pushing/pulling images. Note: by default it will return an ACR Refresh Token with full access (depending on the identity). This can be scoped down to the repository level using .spec.scope. In case scope is defined it will return an ACR Access Token. 
- See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md
-`,
+				Description: "ACRAccessToken returns a Azure Container Registry token that can be used for pushing/pulling images. Note: by default it will return an ACR Refresh Token with full access (depending on the identity). This can be scoped down to the repository level using .spec.scope. In case scope is defined it will return an ACR Access Token. \n See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md",
 				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"apiVersion": apiextensionsv1.JSONSchemaProps{
 						Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -363,12 +360,8 @@ ACRAccessToken returns a Azure Container Registry token that can be used for pus
 								Type:        "string",
 							},
 							"scope": apiextensionsv1.JSONSchemaProps{
-								Description: `
-Define the scope for the access token, e.g. pull/push access for a repository. if not provided it will return a refresh token that has full scope. Note: you need to pin it down to the repository level, there is no wildcard available. 
- examples: repository:my-repository:pull,push repository:my-repository:pull 
- see docs for details: https://docs.docker.com/registry/spec/auth/scope/
-`,
-								Type: "string",
+								Description: "Define the scope for the access token, e.g. pull/push access for a repository. if not provided it will return a refresh token that has full scope. Note: you need to pin it down to the repository level, there is no wildcard available. \n examples: repository:my-repository:pull,push repository:my-repository:pull \n see docs for details: https://docs.docker.com/registry/spec/auth/scope/",
+								Type:        "string",
 							},
 							"tenantId": apiextensionsv1.JSONSchemaProps{
 								Description: "TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.",
@@ -429,11 +422,11 @@ var ClusterexternalsecretsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 				Name:     "Refresh Interval",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason",
 				Name:     "Status",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].status",
 				Name:     "Ready",
 				Type:     "string",
 			}},
@@ -694,7 +687,7 @@ var ClusterexternalsecretsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 									},
 									"refreshInterval": apiextensionsv1.JSONSchemaProps{
 										Default:     &apiextensionsv1.JSON{Raw: []byte("\"1h\"")},
-										Description: `RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero to fetch and create it once. Defaults to 1h.`,
+										Description: "RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\" May be set to zero to fetch and create it once. Defaults to 1h.",
 										Type:        "string",
 									},
 									"secretStoreRef": apiextensionsv1.JSONSchemaProps{
@@ -867,7 +860,7 @@ var ClusterexternalsecretsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 											Allows: true,
 											Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 										},
-										Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+										Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 										Type:        "object",
 									},
 								},
@@ -971,7 +964,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 				Name:     "AGE",
 				Type:     "date",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason",
 				Name:     "Status",
 				Type:     "string",
 			}},
@@ -1330,7 +1323,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 											},
 											"authType": apiextensionsv1.JSONSchemaProps{
 												Default:     &apiextensionsv1.JSON{Raw: []byte("\"ServicePrincipal\"")},
-												Description: `Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)`,
+												Description: "Auth type defines how to authenticate to the keyvault service. Valid values are: - \"ServicePrincipal\" (default): Using a service principal (tenantId, clientId, clientSecret) - \"ManagedIdentity\": Using Managed Identity assigned to the pod (see aad-pod-identity)",
 												Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"ServicePrincipal\"")}, apiextensionsv1.JSON{Raw: []byte("\"ManagedIdentity\"")}, apiextensionsv1.JSON{Raw: []byte("\"WorkloadIdentity\"")}},
 												Type:        "string",
 											},
@@ -1654,7 +1647,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Description: "see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider",
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"key": apiextensionsv1.JSONSchemaProps{
-																Description: `The key the value inside of the provider type to use, only used with "Secret" type`,
+																Description: "The key the value inside of the provider type to use, only used with \"Secret\" type",
 																Type:        "string",
 															},
 															"name": apiextensionsv1.JSONSchemaProps{
@@ -1666,7 +1659,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																Type:        "string",
 															},
 															"type": apiextensionsv1.JSONSchemaProps{
-																Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+																Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 																Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 																Type:        "string",
 															},
@@ -1770,7 +1763,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"approle\"")},
-																Description: `Path where the App Role authentication backend is mounted in Vault, e.g: "approle"`,
+																Description: "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
 																Type:        "string",
 															},
 															"roleId": apiextensionsv1.JSONSchemaProps{
@@ -1883,7 +1876,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 															},
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"jwt\"")},
-																Description: `Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"`,
+																Description: "Path where the JWT authentication backend is mounted in Vault, e.g: \"jwt\"",
 																Type:        "string",
 															},
 															"role": apiextensionsv1.JSONSchemaProps{
@@ -1917,7 +1910,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"mountPath": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"kubernetes\"")},
-																Description: `Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"`,
+																Description: "Path where the Kubernetes authentication backend is mounted in Vault, e.g: \"kubernetes\"",
 																Type:        "string",
 															},
 															"role": apiextensionsv1.JSONSchemaProps{
@@ -1971,7 +1964,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"ldap\"")},
-																Description: `Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"`,
+																Description: "Path where the LDAP authentication backend is mounted in Vault, e.g: \"ldap\"",
 																Type:        "string",
 															},
 															"secretRef": apiextensionsv1.JSONSchemaProps{
@@ -2030,7 +2023,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Description: "The provider for the CA bundle to use to validate Vault server certificate.",
 												Properties: map[string]apiextensionsv1.JSONSchemaProps{
 													"key": apiextensionsv1.JSONSchemaProps{
-														Description: `The key the value inside of the provider type to use, only used with "Secret" type`,
+														Description: "The key the value inside of the provider type to use, only used with \"Secret\" type",
 														Type:        "string",
 													},
 													"name": apiextensionsv1.JSONSchemaProps{
@@ -2042,7 +2035,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Type:        "string",
 													},
 													"type": apiextensionsv1.JSONSchemaProps{
-														Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+														Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 														Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 														Type:        "string",
 													},
@@ -2055,11 +2048,11 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Type:        "boolean",
 											},
 											"namespace": apiextensionsv1.JSONSchemaProps{
-												Description: `Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces`,
+												Description: "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
 												Type:        "string",
 											},
 											"path": apiextensionsv1.JSONSchemaProps{
-												Description: `Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.`,
+												Description: "Path is the mount path of the Vault KV backend endpoint, e.g: \"secret\". The v2 KV secret engine version specific \"/data\" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.",
 												Type:        "string",
 											},
 											"readYourWrites": apiextensionsv1.JSONSchemaProps{
@@ -2067,12 +2060,12 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Type:        "boolean",
 											},
 											"server": apiextensionsv1.JSONSchemaProps{
-												Description: `Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".`,
+												Description: "Server is the connection address for the Vault server, e.g: \"https://vault.example.com:8200\".",
 												Type:        "string",
 											},
 											"version": apiextensionsv1.JSONSchemaProps{
 												Default:     &apiextensionsv1.JSON{Raw: []byte("\"v2\"")},
-												Description: `Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".`,
+												Description: "Version is the Vault KV secret engine version. This can be either \"v1\" or \"v2\". Version defaults to \"v2\".",
 												Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"v1\"")}, apiextensionsv1.JSON{Raw: []byte("\"v2\"")}},
 												Type:        "string",
 											},
@@ -2096,7 +2089,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Description: "The provider for the CA bundle to use to validate webhook server certificate.",
 												Properties: map[string]apiextensionsv1.JSONSchemaProps{
 													"key": apiextensionsv1.JSONSchemaProps{
-														Description: `The key the value inside of the provider type to use, only used with "Secret" type`,
+														Description: "The key the value inside of the provider type to use, only used with \"Secret\" type",
 														Type:        "string",
 													},
 													"name": apiextensionsv1.JSONSchemaProps{
@@ -2108,7 +2101,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Type:        "string",
 													},
 													"type": apiextensionsv1.JSONSchemaProps{
-														Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+														Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 														Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 														Type:        "string",
 													},
@@ -2285,7 +2278,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 				Name:     "AGE",
 				Type:     "date",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason",
 				Name:     "Status",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
@@ -2293,7 +2286,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 				Name:     "Capabilities",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].status",
 				Name:     "Ready",
 				Type:     "string",
 			}},
@@ -2350,7 +2343,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Allows: true,
 														Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 													},
-													Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+													Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 													Type:        "object",
 												},
 											},
@@ -2728,7 +2721,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 											},
 											"authType": apiextensionsv1.JSONSchemaProps{
 												Default:     &apiextensionsv1.JSON{Raw: []byte("\"ServicePrincipal\"")},
-												Description: `Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)`,
+												Description: "Auth type defines how to authenticate to the keyvault service. Valid values are: - \"ServicePrincipal\" (default): Using a service principal (tenantId, clientId, clientSecret) - \"ManagedIdentity\": Using Managed Identity assigned to the pod (see aad-pod-identity)",
 												Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"ServicePrincipal\"")}, apiextensionsv1.JSON{Raw: []byte("\"ManagedIdentity\"")}, apiextensionsv1.JSON{Raw: []byte("\"WorkloadIdentity\"")}},
 												Type:        "string",
 											},
@@ -3150,7 +3143,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																Type:        "string",
 															},
 															"type": apiextensionsv1.JSONSchemaProps{
-																Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+																Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 																Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 																Type:        "string",
 															},
@@ -3347,7 +3340,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"approle\"")},
-																Description: `Path where the App Role authentication backend is mounted in Vault, e.g: "approle"`,
+																Description: "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
 																Type:        "string",
 															},
 															"roleId": apiextensionsv1.JSONSchemaProps{
@@ -3460,7 +3453,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 															},
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"jwt\"")},
-																Description: `Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"`,
+																Description: "Path where the JWT authentication backend is mounted in Vault, e.g: \"jwt\"",
 																Type:        "string",
 															},
 															"role": apiextensionsv1.JSONSchemaProps{
@@ -3494,7 +3487,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"mountPath": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"kubernetes\"")},
-																Description: `Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"`,
+																Description: "Path where the Kubernetes authentication backend is mounted in Vault, e.g: \"kubernetes\"",
 																Type:        "string",
 															},
 															"role": apiextensionsv1.JSONSchemaProps{
@@ -3548,7 +3541,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"ldap\"")},
-																Description: `Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"`,
+																Description: "Path where the LDAP authentication backend is mounted in Vault, e.g: \"ldap\"",
 																Type:        "string",
 															},
 															"secretRef": apiextensionsv1.JSONSchemaProps{
@@ -3619,7 +3612,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Type:        "string",
 													},
 													"type": apiextensionsv1.JSONSchemaProps{
-														Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+														Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 														Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 														Type:        "string",
 													},
@@ -3632,11 +3625,11 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Type:        "boolean",
 											},
 											"namespace": apiextensionsv1.JSONSchemaProps{
-												Description: `Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces`,
+												Description: "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
 												Type:        "string",
 											},
 											"path": apiextensionsv1.JSONSchemaProps{
-												Description: `Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.`,
+												Description: "Path is the mount path of the Vault KV backend endpoint, e.g: \"secret\". The v2 KV secret engine version specific \"/data\" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.",
 												Type:        "string",
 											},
 											"readYourWrites": apiextensionsv1.JSONSchemaProps{
@@ -3644,12 +3637,12 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Type:        "boolean",
 											},
 											"server": apiextensionsv1.JSONSchemaProps{
-												Description: `Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".`,
+												Description: "Server is the connection address for the Vault server, e.g: \"https://vault.example.com:8200\".",
 												Type:        "string",
 											},
 											"version": apiextensionsv1.JSONSchemaProps{
 												Default:     &apiextensionsv1.JSON{Raw: []byte("\"v2\"")},
-												Description: `Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".`,
+												Description: "Version is the Vault KV secret engine version. This can be either \"v1\" or \"v2\". Version defaults to \"v2\".",
 												Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"v1\"")}, apiextensionsv1.JSON{Raw: []byte("\"v2\"")}},
 												Type:        "string",
 											},
@@ -3673,7 +3666,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Description: "The provider for the CA bundle to use to validate webhook server certificate.",
 												Properties: map[string]apiextensionsv1.JSONSchemaProps{
 													"key": apiextensionsv1.JSONSchemaProps{
-														Description: `The key the value inside of the provider type to use, only used with "Secret" type`,
+														Description: "The key the value inside of the provider type to use, only used with \"Secret\" type",
 														Type:        "string",
 													},
 													"name": apiextensionsv1.JSONSchemaProps{
@@ -3685,7 +3678,7 @@ var ClustersecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Type:        "string",
 													},
 													"type": apiextensionsv1.JSONSchemaProps{
-														Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+														Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 														Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 														Type:        "string",
 													},
@@ -4126,7 +4119,7 @@ var ExternalsecretsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 				Name:     "Refresh Interval",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason",
 				Name:     "Status",
 				Type:     "string",
 			}},
@@ -4213,7 +4206,7 @@ var ExternalsecretsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 							},
 							"refreshInterval": apiextensionsv1.JSONSchemaProps{
 								Default:     &apiextensionsv1.JSON{Raw: []byte("\"1h\"")},
-								Description: `RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero to fetch and create it once. Defaults to 1h.`,
+								Description: "RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\" May be set to zero to fetch and create it once. Defaults to 1h.",
 								Type:        "string",
 							},
 							"secretStoreRef": apiextensionsv1.JSONSchemaProps{
@@ -4380,11 +4373,11 @@ var ExternalsecretsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 				Name:     "Refresh Interval",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason",
 				Name:     "Status",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].status",
 				Name:     "Ready",
 				Type:     "string",
 			}},
@@ -4638,7 +4631,7 @@ var ExternalsecretsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 							},
 							"refreshInterval": apiextensionsv1.JSONSchemaProps{
 								Default:     &apiextensionsv1.JSON{Raw: []byte("\"1h\"")},
-								Description: `RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h" May be set to zero to fetch and create it once. Defaults to 1h.`,
+								Description: "RefreshInterval is the amount of time before the values are read again from the SecretStore provider Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\" May be set to zero to fetch and create it once. Defaults to 1h.",
 								Type:        "string",
 							},
 							"secretStoreRef": apiextensionsv1.JSONSchemaProps{
@@ -5134,7 +5127,7 @@ var PushsecretsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 				Name:     "AGE",
 				Type:     "date",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason",
 				Name:     "Status",
 				Type:     "string",
 			}},
@@ -5183,7 +5176,7 @@ var PushsecretsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 							},
 							"deletionPolicy": apiextensionsv1.JSONSchemaProps{
 								Default:     &apiextensionsv1.JSON{Raw: []byte("\"None\"")},
-								Description: `Deletion Policy to handle Secrets in the provider. Possible Values: "Delete/None". Defaults to "None".`,
+								Description: "Deletion Policy to handle Secrets in the provider. Possible Values: \"Delete/None\". Defaults to \"None\".",
 								Type:        "string",
 							},
 							"refreshInterval": apiextensionsv1.JSONSchemaProps{
@@ -5230,7 +5223,7 @@ var PushsecretsIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Allows: true,
 														Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 													},
-													Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+													Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 													Type:        "object",
 												},
 											},
@@ -5385,7 +5378,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 				Name:     "AGE",
 				Type:     "date",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason",
 				Name:     "Status",
 				Type:     "string",
 			}},
@@ -5744,7 +5737,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 											},
 											"authType": apiextensionsv1.JSONSchemaProps{
 												Default:     &apiextensionsv1.JSON{Raw: []byte("\"ServicePrincipal\"")},
-												Description: `Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)`,
+												Description: "Auth type defines how to authenticate to the keyvault service. Valid values are: - \"ServicePrincipal\" (default): Using a service principal (tenantId, clientId, clientSecret) - \"ManagedIdentity\": Using Managed Identity assigned to the pod (see aad-pod-identity)",
 												Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"ServicePrincipal\"")}, apiextensionsv1.JSON{Raw: []byte("\"ManagedIdentity\"")}, apiextensionsv1.JSON{Raw: []byte("\"WorkloadIdentity\"")}},
 												Type:        "string",
 											},
@@ -6068,7 +6061,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Description: "see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider",
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"key": apiextensionsv1.JSONSchemaProps{
-																Description: `The key the value inside of the provider type to use, only used with "Secret" type`,
+																Description: "The key the value inside of the provider type to use, only used with \"Secret\" type",
 																Type:        "string",
 															},
 															"name": apiextensionsv1.JSONSchemaProps{
@@ -6080,7 +6073,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																Type:        "string",
 															},
 															"type": apiextensionsv1.JSONSchemaProps{
-																Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+																Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 																Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 																Type:        "string",
 															},
@@ -6184,7 +6177,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"approle\"")},
-																Description: `Path where the App Role authentication backend is mounted in Vault, e.g: "approle"`,
+																Description: "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
 																Type:        "string",
 															},
 															"roleId": apiextensionsv1.JSONSchemaProps{
@@ -6297,7 +6290,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 															},
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"jwt\"")},
-																Description: `Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"`,
+																Description: "Path where the JWT authentication backend is mounted in Vault, e.g: \"jwt\"",
 																Type:        "string",
 															},
 															"role": apiextensionsv1.JSONSchemaProps{
@@ -6331,7 +6324,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"mountPath": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"kubernetes\"")},
-																Description: `Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"`,
+																Description: "Path where the Kubernetes authentication backend is mounted in Vault, e.g: \"kubernetes\"",
 																Type:        "string",
 															},
 															"role": apiextensionsv1.JSONSchemaProps{
@@ -6385,7 +6378,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"ldap\"")},
-																Description: `Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"`,
+																Description: "Path where the LDAP authentication backend is mounted in Vault, e.g: \"ldap\"",
 																Type:        "string",
 															},
 															"secretRef": apiextensionsv1.JSONSchemaProps{
@@ -6444,7 +6437,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Description: "The provider for the CA bundle to use to validate Vault server certificate.",
 												Properties: map[string]apiextensionsv1.JSONSchemaProps{
 													"key": apiextensionsv1.JSONSchemaProps{
-														Description: `The key the value inside of the provider type to use, only used with "Secret" type`,
+														Description: "The key the value inside of the provider type to use, only used with \"Secret\" type",
 														Type:        "string",
 													},
 													"name": apiextensionsv1.JSONSchemaProps{
@@ -6456,7 +6449,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Type:        "string",
 													},
 													"type": apiextensionsv1.JSONSchemaProps{
-														Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+														Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 														Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 														Type:        "string",
 													},
@@ -6469,11 +6462,11 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Type:        "boolean",
 											},
 											"namespace": apiextensionsv1.JSONSchemaProps{
-												Description: `Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces`,
+												Description: "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
 												Type:        "string",
 											},
 											"path": apiextensionsv1.JSONSchemaProps{
-												Description: `Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.`,
+												Description: "Path is the mount path of the Vault KV backend endpoint, e.g: \"secret\". The v2 KV secret engine version specific \"/data\" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.",
 												Type:        "string",
 											},
 											"readYourWrites": apiextensionsv1.JSONSchemaProps{
@@ -6481,12 +6474,12 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Type:        "boolean",
 											},
 											"server": apiextensionsv1.JSONSchemaProps{
-												Description: `Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".`,
+												Description: "Server is the connection address for the Vault server, e.g: \"https://vault.example.com:8200\".",
 												Type:        "string",
 											},
 											"version": apiextensionsv1.JSONSchemaProps{
 												Default:     &apiextensionsv1.JSON{Raw: []byte("\"v2\"")},
-												Description: `Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".`,
+												Description: "Version is the Vault KV secret engine version. This can be either \"v1\" or \"v2\". Version defaults to \"v2\".",
 												Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"v1\"")}, apiextensionsv1.JSON{Raw: []byte("\"v2\"")}},
 												Type:        "string",
 											},
@@ -6510,7 +6503,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Description: "The provider for the CA bundle to use to validate webhook server certificate.",
 												Properties: map[string]apiextensionsv1.JSONSchemaProps{
 													"key": apiextensionsv1.JSONSchemaProps{
-														Description: `The key the value inside of the provider type to use, only used with "Secret" type`,
+														Description: "The key the value inside of the provider type to use, only used with \"Secret\" type",
 														Type:        "string",
 													},
 													"name": apiextensionsv1.JSONSchemaProps{
@@ -6522,7 +6515,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Type:        "string",
 													},
 													"type": apiextensionsv1.JSONSchemaProps{
-														Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+														Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 														Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 														Type:        "string",
 													},
@@ -6699,7 +6692,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 				Name:     "AGE",
 				Type:     "date",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason",
 				Name:     "Status",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
@@ -6707,7 +6700,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 				Name:     "Capabilities",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Ready")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Ready\")].status",
 				Name:     "Ready",
 				Type:     "string",
 			}},
@@ -6764,7 +6757,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Allows: true,
 														Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
 													},
-													Description: `matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.`,
+													Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
 													Type:        "object",
 												},
 											},
@@ -7142,7 +7135,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 											},
 											"authType": apiextensionsv1.JSONSchemaProps{
 												Default:     &apiextensionsv1.JSON{Raw: []byte("\"ServicePrincipal\"")},
-												Description: `Auth type defines how to authenticate to the keyvault service. Valid values are: - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret) - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)`,
+												Description: "Auth type defines how to authenticate to the keyvault service. Valid values are: - \"ServicePrincipal\" (default): Using a service principal (tenantId, clientId, clientSecret) - \"ManagedIdentity\": Using Managed Identity assigned to the pod (see aad-pod-identity)",
 												Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"ServicePrincipal\"")}, apiextensionsv1.JSON{Raw: []byte("\"ManagedIdentity\"")}, apiextensionsv1.JSON{Raw: []byte("\"WorkloadIdentity\"")}},
 												Type:        "string",
 											},
@@ -7564,7 +7557,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 																Type:        "string",
 															},
 															"type": apiextensionsv1.JSONSchemaProps{
-																Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+																Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 																Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 																Type:        "string",
 															},
@@ -7761,7 +7754,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"approle\"")},
-																Description: `Path where the App Role authentication backend is mounted in Vault, e.g: "approle"`,
+																Description: "Path where the App Role authentication backend is mounted in Vault, e.g: \"approle\"",
 																Type:        "string",
 															},
 															"roleId": apiextensionsv1.JSONSchemaProps{
@@ -7874,7 +7867,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 															},
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"jwt\"")},
-																Description: `Path where the JWT authentication backend is mounted in Vault, e.g: "jwt"`,
+																Description: "Path where the JWT authentication backend is mounted in Vault, e.g: \"jwt\"",
 																Type:        "string",
 															},
 															"role": apiextensionsv1.JSONSchemaProps{
@@ -7908,7 +7901,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"mountPath": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"kubernetes\"")},
-																Description: `Path where the Kubernetes authentication backend is mounted in Vault, e.g: "kubernetes"`,
+																Description: "Path where the Kubernetes authentication backend is mounted in Vault, e.g: \"kubernetes\"",
 																Type:        "string",
 															},
 															"role": apiextensionsv1.JSONSchemaProps{
@@ -7962,7 +7955,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Properties: map[string]apiextensionsv1.JSONSchemaProps{
 															"path": apiextensionsv1.JSONSchemaProps{
 																Default:     &apiextensionsv1.JSON{Raw: []byte("\"ldap\"")},
-																Description: `Path where the LDAP authentication backend is mounted in Vault, e.g: "ldap"`,
+																Description: "Path where the LDAP authentication backend is mounted in Vault, e.g: \"ldap\"",
 																Type:        "string",
 															},
 															"secretRef": apiextensionsv1.JSONSchemaProps{
@@ -8033,7 +8026,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Type:        "string",
 													},
 													"type": apiextensionsv1.JSONSchemaProps{
-														Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+														Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 														Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 														Type:        "string",
 													},
@@ -8046,11 +8039,11 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Type:        "boolean",
 											},
 											"namespace": apiextensionsv1.JSONSchemaProps{
-												Description: `Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces`,
+												Description: "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\". More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
 												Type:        "string",
 											},
 											"path": apiextensionsv1.JSONSchemaProps{
-												Description: `Path is the mount path of the Vault KV backend endpoint, e.g: "secret". The v2 KV secret engine version specific "/data" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.`,
+												Description: "Path is the mount path of the Vault KV backend endpoint, e.g: \"secret\". The v2 KV secret engine version specific \"/data\" path suffix for fetching secrets from Vault is optional and will be appended if not present in specified path.",
 												Type:        "string",
 											},
 											"readYourWrites": apiextensionsv1.JSONSchemaProps{
@@ -8058,12 +8051,12 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Type:        "boolean",
 											},
 											"server": apiextensionsv1.JSONSchemaProps{
-												Description: `Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".`,
+												Description: "Server is the connection address for the Vault server, e.g: \"https://vault.example.com:8200\".",
 												Type:        "string",
 											},
 											"version": apiextensionsv1.JSONSchemaProps{
 												Default:     &apiextensionsv1.JSON{Raw: []byte("\"v2\"")},
-												Description: `Version is the Vault KV secret engine version. This can be either "v1" or "v2". Version defaults to "v2".`,
+												Description: "Version is the Vault KV secret engine version. This can be either \"v1\" or \"v2\". Version defaults to \"v2\".",
 												Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"v1\"")}, apiextensionsv1.JSON{Raw: []byte("\"v2\"")}},
 												Type:        "string",
 											},
@@ -8087,7 +8080,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 												Description: "The provider for the CA bundle to use to validate webhook server certificate.",
 												Properties: map[string]apiextensionsv1.JSONSchemaProps{
 													"key": apiextensionsv1.JSONSchemaProps{
-														Description: `The key the value inside of the provider type to use, only used with "Secret" type`,
+														Description: "The key the value inside of the provider type to use, only used with \"Secret\" type",
 														Type:        "string",
 													},
 													"name": apiextensionsv1.JSONSchemaProps{
@@ -8099,7 +8092,7 @@ var SecretstoresIoCRD = &apiextensionsv1.CustomResourceDefinition{
 														Type:        "string",
 													},
 													"type": apiextensionsv1.JSONSchemaProps{
-														Description: `The type of provider to use such as "Secret", or "ConfigMap".`,
+														Description: "The type of provider to use such as \"Secret\", or \"ConfigMap\".",
 														Enum:        []apiextensionsv1.JSON{apiextensionsv1.JSON{Raw: []byte("\"Secret\"")}, apiextensionsv1.JSON{Raw: []byte("\"ConfigMap\"")}},
 														Type:        "string",
 													},

--- a/pkg/kube/testdata/golden/import_with_group_kind_and_clean_name.txt
+++ b/pkg/kube/testdata/golden/import_with_group_kind_and_clean_name.txt
@@ -452,33 +452,7 @@ var ConfigLoggingCM = &corev1.ConfigMap{
 		// Log level overrides
 		"loglevel.controller": "info",
 		"loglevel.webhook":    "info",
-		"zap-logger-config": `
-{
-  "level": "info",
-  "development": false,
-  "sampling": {
-    "initial": 100,
-    "thereafter": 100
-  },
-  "outputPaths": ["stdout"],
-  "errorOutputPaths": ["stderr"],
-  "encoding": "json",
-  "encoderConfig": {
-    "timeKey": "timestamp",
-    "levelKey": "severity",
-    "nameKey": "logger",
-    "callerKey": "caller",
-    "messageKey": "message",
-    "stacktraceKey": "stacktrace",
-    "lineEnding": "",
-    "levelEncoder": "",
-    "timeEncoder": "iso8601",
-    "durationEncoder": "",
-    "callerEncoder": ""
-  }
-}
-
-`},
+		"zap-logger-config":   "{\n  \"level\": \"info\",\n  \"development\": false,\n  \"sampling\": {\n    \"initial\": 100,\n    \"thereafter\": 100\n  },\n  \"outputPaths\": [\"stdout\"],\n  \"errorOutputPaths\": [\"stderr\"],\n  \"encoding\": \"json\",\n  \"encoderConfig\": {\n    \"timeKey\": \"timestamp\",\n    \"levelKey\": \"severity\",\n    \"nameKey\": \"logger\",\n    \"callerKey\": \"caller\",\n    \"messageKey\": \"message\",\n    \"stacktraceKey\": \"stacktrace\",\n    \"lineEnding\": \"\",\n    \"levelEncoder\": \"\",\n    \"timeEncoder\": \"iso8601\",\n    \"durationEncoder\": \"\",\n    \"callerEncoder\": \"\"\n  }\n}\n"},
 	ObjectMeta: metav1.ObjectMeta{
 		Labels: map[string]string{
 			"app.kubernetes.io/instance": "default",
@@ -498,33 +472,7 @@ var ConfigLoggingCM2 = &corev1.ConfigMap{
 		// Log level overrides
 		"loglevel.controller": "info",
 		"loglevel.webhook":    "info",
-		"zap-logger-config": `
-{
-  "level": "info",
-  "development": false,
-  "sampling": {
-    "initial": 100,
-    "thereafter": 100
-  },
-  "outputPaths": ["stdout"],
-  "errorOutputPaths": ["stderr"],
-  "encoding": "json",
-  "encoderConfig": {
-    "timeKey": "timestamp",
-    "levelKey": "severity",
-    "nameKey": "logger",
-    "callerKey": "caller",
-    "messageKey": "message",
-    "stacktraceKey": "stacktrace",
-    "lineEnding": "",
-    "levelEncoder": "",
-    "timeEncoder": "iso8601",
-    "durationEncoder": "",
-    "callerEncoder": ""
-  }
-}
-
-`},
+		"zap-logger-config":   "{\n  \"level\": \"info\",\n  \"development\": false,\n  \"sampling\": {\n    \"initial\": 100,\n    \"thereafter\": 100\n  },\n  \"outputPaths\": [\"stdout\"],\n  \"errorOutputPaths\": [\"stderr\"],\n  \"encoding\": \"json\",\n  \"encoderConfig\": {\n    \"timeKey\": \"timestamp\",\n    \"levelKey\": \"severity\",\n    \"nameKey\": \"logger\",\n    \"callerKey\": \"caller\",\n    \"messageKey\": \"message\",\n    \"stacktraceKey\": \"stacktrace\",\n    \"lineEnding\": \"\",\n    \"levelEncoder\": \"\",\n    \"timeEncoder\": \"iso8601\",\n    \"durationEncoder\": \"\",\n    \"callerEncoder\": \"\"\n  }\n}\n"},
 	ObjectMeta: metav1.ObjectMeta{
 		Labels: map[string]string{
 			"app.kubernetes.io/component": "resolvers",
@@ -928,11 +876,11 @@ var CustomrunsDevCRD = &apiextensionsv1.CustomResourceDefinition{
 		Scope: apiextensionsv1.ResourceScope("Namespaced"),
 		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{apiextensionsv1.CustomResourceDefinitionVersion{
 			AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status",
 				Name:     "Succeeded",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason",
 				Name:     "Reason",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
@@ -1028,11 +976,11 @@ var PipelinerunsDevCRD = &apiextensionsv1.CustomResourceDefinition{
 		Scope: apiextensionsv1.ResourceScope("Namespaced"),
 		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{apiextensionsv1.CustomResourceDefinitionVersion{
 			AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status",
 				Name:     "Succeeded",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason",
 				Name:     "Reason",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
@@ -1054,11 +1002,11 @@ var PipelinerunsDevCRD = &apiextensionsv1.CustomResourceDefinition{
 			Subresources: &apiextensionsv1.CustomResourceSubresources{Status: &apiextensionsv1.CustomResourceSubresourceStatus{}},
 		}, apiextensionsv1.CustomResourceDefinitionVersion{
 			AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status",
 				Name:     "Succeeded",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason",
 				Name:     "Reason",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
@@ -1245,11 +1193,11 @@ var RunsDevCRD = &apiextensionsv1.CustomResourceDefinition{
 		Scope: apiextensionsv1.ResourceScope("Namespaced"),
 		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{apiextensionsv1.CustomResourceDefinitionVersion{
 			AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status",
 				Name:     "Succeeded",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason",
 				Name:     "Reason",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
@@ -1309,11 +1257,11 @@ var TaskrunsDevCRD = &apiextensionsv1.CustomResourceDefinition{
 		Scope: apiextensionsv1.ResourceScope("Namespaced"),
 		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{apiextensionsv1.CustomResourceDefinitionVersion{
 			AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status",
 				Name:     "Succeeded",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason",
 				Name:     "Reason",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
@@ -1335,11 +1283,11 @@ var TaskrunsDevCRD = &apiextensionsv1.CustomResourceDefinition{
 			Subresources: &apiextensionsv1.CustomResourceSubresources{Status: &apiextensionsv1.CustomResourceSubresourceStatus{}},
 		}, apiextensionsv1.CustomResourceDefinitionVersion{
 			AdditionalPrinterColumns: []apiextensionsv1.CustomResourceColumnDefinition{apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].status`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status",
 				Name:     "Succeeded",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{
-				JSONPath: `.status.conditions[?(@.type=="Succeeded")].reason`,
+				JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason",
 				Name:     "Reason",
 				Type:     "string",
 			}, apiextensionsv1.CustomResourceColumnDefinition{

--- a/pkg/kube/testdata/golden/import_with_vanilla_serializer_and_add_methods.txt
+++ b/pkg/kube/testdata/golden/import_with_vanilla_serializer_and_add_methods.txt
@@ -73,65 +73,10 @@ import (
 
 var CM = &corev1.ConfigMap{
 	Data: map[string]string{
-		"dashboardproviders.yaml": `
-apiVersion: 1
-providers:
-- disableDeletion: false
-  editable: true
-  folder: ""
-  name: default
-  options:
-    path: /var/lib/grafana/dashboards/default
-  orgId: 1
-  type: file
-
-`,
-		"datasources.yaml": `
-apiVersion: 1
-datasources:
-- access: proxy
-  name: Prometheus
-  type: prometheus
-  url: http://prometheus-server:80
-  version: 1
-
-`,
-		"download_dashboards.sh": `
-#!/usr/bin/env sh
-set -euf
-mkdir -p /var/lib/grafana/dashboards/default
-curl -skf \
---connect-timeout 60 \
---max-time 60 \
--H "Accept: application/json" \
--H "Content-Type: application/json;charset=UTF-8" \
-  "https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json" \
-> "/var/lib/grafana/dashboards/default/capacity-dashboard.json"
-curl -skf \
---connect-timeout 60 \
---max-time 60 \
--H "Accept: application/json" \
--H "Content-Type: application/json;charset=UTF-8" \
-  "https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-performance-dashboard.json" \
-> "/var/lib/grafana/dashboards/default/performance-dashboard.json"
-
-`,
-		"grafana.ini": `
-[analytics]
-check_for_updates = true
-[grafana_net]
-url = https://grafana.net
-[log]
-mode = console
-[paths]
-data = /var/lib/grafana/
-logs = /var/log/grafana
-plugins = /var/lib/grafana/plugins
-provisioning = /etc/grafana/provisioning
-[server]
-domain = ''
-
-`},
+		"dashboardproviders.yaml": "apiVersion: 1\nproviders:\n- disableDeletion: false\n  editable: true\n  folder: \"\"\n  name: default\n  options:\n    path: /var/lib/grafana/dashboards/default\n  orgId: 1\n  type: file\n",
+		"datasources.yaml":        "apiVersion: 1\ndatasources:\n- access: proxy\n  name: Prometheus\n  type: prometheus\n  url: http://prometheus-server:80\n  version: 1\n",
+		"download_dashboards.sh":  "#!/usr/bin/env sh\nset -euf\nmkdir -p /var/lib/grafana/dashboards/default\ncurl -skf \\\n--connect-timeout 60 \\\n--max-time 60 \\\n-H \"Accept: application/json\" \\\n-H \"Content-Type: application/json;charset=UTF-8\" \\\n  \"https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json\" \\\n> \"/var/lib/grafana/dashboards/default/capacity-dashboard.json\"\ncurl -skf \\\n--connect-timeout 60 \\\n--max-time 60 \\\n-H \"Accept: application/json\" \\\n-H \"Content-Type: application/json;charset=UTF-8\" \\\n  \"https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-performance-dashboard.json\" \\\n> \"/var/lib/grafana/dashboards/default/performance-dashboard.json\"\n",
+		"grafana.ini":             "[analytics]\ncheck_for_updates = true\n[grafana_net]\nurl = https://grafana.net\n[log]\nmode = console\n[paths]\ndata = /var/lib/grafana/\nlogs = /var/log/grafana\nplugins = /var/lib/grafana/plugins\nprovisioning = /etc/grafana/provisioning\n[server]\ndomain = ''\n"},
 	ObjectMeta: metav1.ObjectMeta{
 		Labels: map[string]string{
 			"app.kubernetes.io/instance":   "grafana",
@@ -171,13 +116,7 @@ var DashboardsDefaultCM = &corev1.ConfigMap{
 
 var TestCM = &corev1.ConfigMap{
 	Data: map[string]string{
-		"run.sh": `
-@test "Test Health" {
-  url="http://grafana/api/health"
-  code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
-  [ "$code" == "200" ]
-}
-`},
+		"run.sh": "@test \"Test Health\" {\n  url=\"http://grafana/api/health\"\n  code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')\n  [ \"$code\" == \"200\" ]\n}"},
 	ObjectMeta: metav1.ObjectMeta{
 		Annotations: map[string]string{
 			"helm.sh/hook":               "test-success",

--- a/pkg/kube/testdata/golden/import_with_vanilla_serializer_and_remove_app_name_and_group_by_kind.txt
+++ b/pkg/kube/testdata/golden/import_with_vanilla_serializer_and_remove_app_name_and_group_by_kind.txt
@@ -73,65 +73,10 @@ import (
 
 var CM = &corev1.ConfigMap{
 	Data: map[string]string{
-		"dashboardproviders.yaml": `
-apiVersion: 1
-providers:
-- disableDeletion: false
-  editable: true
-  folder: ""
-  name: default
-  options:
-    path: /var/lib/grafana/dashboards/default
-  orgId: 1
-  type: file
-
-`,
-		"datasources.yaml": `
-apiVersion: 1
-datasources:
-- access: proxy
-  name: Prometheus
-  type: prometheus
-  url: http://prometheus-server:80
-  version: 1
-
-`,
-		"download_dashboards.sh": `
-#!/usr/bin/env sh
-set -euf
-mkdir -p /var/lib/grafana/dashboards/default
-curl -skf \
---connect-timeout 60 \
---max-time 60 \
--H "Accept: application/json" \
--H "Content-Type: application/json;charset=UTF-8" \
-  "https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json" \
-> "/var/lib/grafana/dashboards/default/capacity-dashboard.json"
-curl -skf \
---connect-timeout 60 \
---max-time 60 \
--H "Accept: application/json" \
--H "Content-Type: application/json;charset=UTF-8" \
-  "https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-performance-dashboard.json" \
-> "/var/lib/grafana/dashboards/default/performance-dashboard.json"
-
-`,
-		"grafana.ini": `
-[analytics]
-check_for_updates = true
-[grafana_net]
-url = https://grafana.net
-[log]
-mode = console
-[paths]
-data = /var/lib/grafana/
-logs = /var/log/grafana
-plugins = /var/lib/grafana/plugins
-provisioning = /etc/grafana/provisioning
-[server]
-domain = ''
-
-`},
+		"dashboardproviders.yaml": "apiVersion: 1\nproviders:\n- disableDeletion: false\n  editable: true\n  folder: \"\"\n  name: default\n  options:\n    path: /var/lib/grafana/dashboards/default\n  orgId: 1\n  type: file\n",
+		"datasources.yaml":        "apiVersion: 1\ndatasources:\n- access: proxy\n  name: Prometheus\n  type: prometheus\n  url: http://prometheus-server:80\n  version: 1\n",
+		"download_dashboards.sh":  "#!/usr/bin/env sh\nset -euf\nmkdir -p /var/lib/grafana/dashboards/default\ncurl -skf \\\n--connect-timeout 60 \\\n--max-time 60 \\\n-H \"Accept: application/json\" \\\n-H \"Content-Type: application/json;charset=UTF-8\" \\\n  \"https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-capacity-dashboard.json\" \\\n> \"/var/lib/grafana/dashboards/default/capacity-dashboard.json\"\ncurl -skf \\\n--connect-timeout 60 \\\n--max-time 60 \\\n-H \"Accept: application/json\" \\\n-H \"Content-Type: application/json;charset=UTF-8\" \\\n  \"https://karpenter.sh/v0.24.0/getting-started/getting-started-with-eksctl/karpenter-performance-dashboard.json\" \\\n> \"/var/lib/grafana/dashboards/default/performance-dashboard.json\"\n",
+		"grafana.ini":             "[analytics]\ncheck_for_updates = true\n[grafana_net]\nurl = https://grafana.net\n[log]\nmode = console\n[paths]\ndata = /var/lib/grafana/\nlogs = /var/log/grafana\nplugins = /var/lib/grafana/plugins\nprovisioning = /etc/grafana/provisioning\n[server]\ndomain = ''\n"},
 	ObjectMeta: metav1.ObjectMeta{
 		Labels: map[string]string{
 			"app.kubernetes.io/instance":   "grafana",
@@ -171,13 +116,7 @@ var DashboardsDefaultCM = &corev1.ConfigMap{
 
 var TestCM = &corev1.ConfigMap{
 	Data: map[string]string{
-		"run.sh": `
-@test "Test Health" {
-  url="http://grafana/api/health"
-  code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
-  [ "$code" == "200" ]
-}
-`},
+		"run.sh": "@test \"Test Health\" {\n  url=\"http://grafana/api/health\"\n  code=$(wget --server-response --spider --timeout 90 --tries 10 ${url} 2>&1 | awk '/^  HTTP/{print $2}')\n  [ \"$code\" == \"200\" ]\n}"},
 	ObjectMeta: metav1.ObjectMeta{
 		Annotations: map[string]string{
 			"helm.sh/hook":               "test-success",

--- a/pkg/kube/testdata/golden/log.golden
+++ b/pkg/kube/testdata/golden/log.golden
@@ -80,4 +80,4 @@ level=INFO msg=render app=lingon filename=out/import/tekton/secret.go
 level=INFO msg=render app=lingon filename=out/import/tekton/service.go
 level=INFO msg=render app=lingon filename=out/import/tekton/service-account.go
 level=INFO msg=render app=lingon filename=out/import/tekton/validating-webhook-configuration.go
-level=INFO msg=output app=lingon "bytes written"=113462
+level=INFO msg=output app=lingon "bytes written"=113674


### PR DESCRIPTION
Make string handling in generated Go code simple.
If a user wants to own the code, they can tidy it up afterwards.
This will avoid any complications with strings in things like CRDs
where the automated modifications can change the apply'd string.

This will also keep maintenane of kygo easier, because we won't support
anything other than raw strings.
