### PR TITLE
downgrade go directive and use toolchain for higher version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/golingon/lingon
 
-go 1.23.2
+go 1.22.2
+
+toolchain go1.23.2
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
A high Go directive forces users of lingon to upgrade to at least that version.
